### PR TITLE
Documents clients

### DIFF
--- a/src/components/atoms/ChannelBR/channelbr.scss
+++ b/src/components/atoms/ChannelBR/channelbr.scss
@@ -14,7 +14,7 @@
     }
 
     .titleLineBR {
-        font-size: 1.2rem;
+        font-size: 1rem;
     }
 
     .subtitleLineBR {

--- a/src/components/atoms/DocumentCards/DocumentCards.tsx
+++ b/src/components/atoms/DocumentCards/DocumentCards.tsx
@@ -1,0 +1,47 @@
+import { Flex, Checkbox, Button, Typography, Spin } from "antd";
+import { FileArrowUp } from "phosphor-react";
+import { useDocumentByClient } from "@/hooks/useDocumentByClient";
+import "./documentCards.scss";
+
+const { Text } = Typography;
+
+interface Props {
+  clientTypeId: number;
+}
+
+export const DocumentCards = ({ clientTypeId }: Props) => {
+  const { data, isLoading } = useDocumentByClient(clientTypeId);
+  console.log("data en DOCCARD: ", data?.data);
+  const documents = data?.data;
+  return (
+    <>
+      {isLoading ? (
+        <Spin />
+      ) : (
+        <div className="documentCards">
+          {documents?.map((doc) => (
+            <Flex className="documentCard" key={doc.id} vertical>
+              <Text className="documentCard__title">nombre documento</Text>
+              <Checkbox className="documentCard__check" checked={Boolean(doc.required)}>
+                Obligatorio
+              </Checkbox>
+              {doc.format_document && (
+                <Button
+                  type="text"
+                  icon={
+                    <FileArrowUp className="documentCard__documentTemplate__icon" size={"16px"} />
+                  }
+                  className="documentCard__documentTemplate"
+                  href={doc.format_document}
+                  target="_blank"
+                >
+                  {doc.format_document.split("/").pop()}.
+                </Button>
+              )}
+            </Flex>
+          ))}
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/components/atoms/DocumentCards/DocumentCards.tsx
+++ b/src/components/atoms/DocumentCards/DocumentCards.tsx
@@ -1,5 +1,5 @@
 import { Flex, Checkbox, Button, Typography, Spin } from "antd";
-import { FileArrowUp } from "phosphor-react";
+import { FileArrowUp, X } from "phosphor-react";
 import { useDocumentByClient } from "@/hooks/useDocumentByClient";
 import "./documentCards.scss";
 
@@ -7,11 +7,11 @@ const { Text } = Typography;
 
 interface Props {
   clientTypeId: number;
+  isDisabledEdit: boolean;
 }
 
-export const DocumentCards = ({ clientTypeId }: Props) => {
+export const DocumentCards = ({ clientTypeId, isDisabledEdit }: Props) => {
   const { data, isLoading } = useDocumentByClient(clientTypeId);
-  console.log("data en DOCCARD: ", data?.data);
   const documents = data?.data;
   return (
     <>
@@ -21,7 +21,10 @@ export const DocumentCards = ({ clientTypeId }: Props) => {
         <div className="documentCards">
           {documents?.map((doc) => (
             <Flex className="documentCard" key={doc.id} vertical>
-              <Text className="documentCard__title">nombre documento</Text>
+              <Flex justify="space-between">
+                <Text className="documentCard__title">{doc.format_document.split("/").pop()}</Text>
+                {!isDisabledEdit && <Button icon={<X size={"16px"} />} className="removebutton" />}
+              </Flex>
               <Checkbox className="documentCard__check" checked={Boolean(doc.required)}>
                 Obligatorio
               </Checkbox>

--- a/src/components/atoms/DocumentCards/documentCards.scss
+++ b/src/components/atoms/DocumentCards/documentCards.scss
@@ -38,6 +38,7 @@
         }
         span {
             width: fit-content;
+            text-decoration: underline;
         }
     }
 }

--- a/src/components/atoms/DocumentCards/documentCards.scss
+++ b/src/components/atoms/DocumentCards/documentCards.scss
@@ -1,0 +1,43 @@
+@import "@styles/variables.scss";
+
+.documentCards {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+.documentCard {
+    border: 1.4px solid $dark-gray;
+    border-radius: 0.5rem;
+    padding: 0.5rem 1rem 0.875rem 1rem;
+    gap: 0.5rem;
+
+    &__title {
+        font-size: 1rem;
+        font-weight: 300;
+    }
+
+    &__check {
+        font-weight: 300;
+        font-size: 1rem;
+    }
+
+    &__documentTemplate {
+        display: flex !important;
+        justify-content: flex-start;
+        align-items: center;
+        padding: 0 !important;
+        font-weight: 300 !important;
+        font-size: 0.875rem !important;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        height: fit-content !important;
+
+        &__icon {
+            width: fit-content;
+        }
+        span {
+            width: fit-content;
+        }
+    }
+}

--- a/src/components/atoms/DocumentClientBR/DocumentClientBR.tsx
+++ b/src/components/atoms/DocumentClientBR/DocumentClientBR.tsx
@@ -1,8 +1,9 @@
-import { Button, Checkbox, Flex, Spin, Typography } from "antd";
+import { Button, Checkbox, Flex, Popover, Spin, Typography } from "antd";
 import { CaretDoubleRight, FileArrowUp, X } from "phosphor-react";
 
 import { useDocumentByClient } from "@/hooks/useDocumentByClient";
 import "./documentclientbr.scss";
+import { InputCreateDocument } from "../inputs/inputCreate/InputCreateDocument";
 
 const { Text } = Typography;
 
@@ -12,8 +13,6 @@ interface Props {
 
 export const DocumentClientBR = ({ isDisabledEdit }: Props) => {
   const { data, isLoading } = useDocumentByClient();
-  console.log(data);
-
   return (
     <div className="contianerdocumentclientbr">
       <Typography.Text className="title">Documentos por cliente</Typography.Text>
@@ -52,13 +51,20 @@ export const DocumentClientBR = ({ isDisabledEdit }: Props) => {
                     </Flex>
                   </Flex>
                   {!isDisabledEdit && (
-                    <Button
-                      icon={<CaretDoubleRight size={"16px"} />}
-                      className="addButtonLineSub"
-                      type="text"
+                    <Popover
+                      className=""
+                      content={<InputCreateDocument isEditAvailable />}
+                      trigger="click"
+                      placement="bottom"
                     >
-                      Agregar documento
-                    </Button>
+                      <Button
+                        icon={<CaretDoubleRight size={"16px"} />}
+                        className="addButtonLineSub"
+                        type="text"
+                      >
+                        Agregar documento
+                      </Button>
+                    </Popover>
                   )}
                 </Flex>
                 {!isDisabledEdit && (

--- a/src/components/atoms/DocumentClientBR/DocumentClientBR.tsx
+++ b/src/components/atoms/DocumentClientBR/DocumentClientBR.tsx
@@ -1,8 +1,10 @@
-import { Button, Checkbox, Flex, Popover, Spin, Typography } from "antd";
-import { CaretDoubleRight, FileArrowUp, X } from "phosphor-react";
+import { Button, Flex, Popover, Spin, Typography } from "antd";
+import { CaretDoubleRight, X } from "phosphor-react";
 
-import { useDocumentByClient } from "@/hooks/useDocumentByClient";
 import "./documentclientbr.scss";
+import { useClientTypes } from "@/hooks/useClientTypes";
+import { InputCreateClientType } from "@/components/atoms/inputs/InputCreateClientType/InputCreateClientType";
+import { DocumentCards } from "@/components/atoms/DocumentCards/DocumentCards";
 import { InputCreateDocument } from "../inputs/inputCreate/InputCreateDocument";
 
 const { Text } = Typography;
@@ -12,73 +14,62 @@ interface Props {
 }
 
 export const DocumentClientBR = ({ isDisabledEdit }: Props) => {
-  const { data, isLoading } = useDocumentByClient();
+  const { data, loading } = useClientTypes();
+  // const data = [];
+  // const loading = false;
+  console.log(data);
+
   return (
     <div className="contianerdocumentclientbr">
       <Typography.Text className="title">Documentos por cliente</Typography.Text>
-      <Flex vertical className="holdings">
-        {isLoading ? (
+      <Flex vertical className="clientTypes">
+        {loading ? (
           <Spin />
         ) : (
-          <>
-            {data?.data.map((document) => (
-              <Flex className="documentclientbr" key={document.id} vertical>
+          <Flex className="documentclientbr" vertical>
+            {data?.map((document) => (
+              <Flex className="clientTypeCard" vertical key={document.id}>
                 <Flex justify="space-between">
-                  <Text className="titleLineBR">Institucional</Text>
+                  <Text className="clientTypeCard__title">{document.clientType}</Text>
                   {!isDisabledEdit && (
                     <Button icon={<X size={"16px"} />} className="removebutton" />
                   )}
                 </Flex>
-                <Flex className="lineBR" vertical>
-                  <Flex justify="space-between">
-                    <Text className="subtitleLineBR">Creacion de Cliente</Text>
-                    {!isDisabledEdit && (
-                      <Button icon={<X size={"16px"} />} className="removebutton" />
-                    )}
-                  </Flex>
-                  <Flex className="mainSublinesBR">
-                    <Flex vertical>
-                      <Checkbox checked={document.required === 1}>Obligatorio</Checkbox>
-                      <Button
-                        type="text"
-                        icon={<FileArrowUp size={"16px"} />}
-                        className="buttonTextDocument"
-                        href={document.format_document}
-                        target="_blank"
-                      >
-                        Plantilla_Creacion_de_Cliente
-                      </Button>
-                    </Flex>
-                  </Flex>
-                  {!isDisabledEdit && (
-                    <Popover
-                      className=""
-                      content={<InputCreateDocument isEditAvailable />}
-                      trigger="click"
-                      placement="bottom"
-                    >
-                      <Button
-                        icon={<CaretDoubleRight size={"16px"} />}
-                        className="addButtonLineSub"
-                        type="text"
-                      >
-                        Agregar documento
-                      </Button>
-                    </Popover>
-                  )}
-                </Flex>
+                <DocumentCards clientTypeId={document.id} />
+
                 {!isDisabledEdit && (
-                  <Button
-                    icon={<CaretDoubleRight size={"16px"} />}
-                    className="addButtonLineSub"
-                    type="text"
+                  <Popover
+                    content={<InputCreateDocument isEditAvailable={false} />}
+                    trigger="click"
+                    placement="bottom"
                   >
-                    Agregar cliente
-                  </Button>
+                    <Button
+                      icon={<CaretDoubleRight size={"16px"} />}
+                      className="addButtonLineSub"
+                      type="text"
+                    >
+                      Agregar documento
+                    </Button>
+                  </Popover>
                 )}
               </Flex>
             ))}
-          </>
+            {!isDisabledEdit && (
+              <Popover
+                content={<InputCreateClientType isEditAvailable={!isDisabledEdit} />}
+                trigger="click"
+                placement="bottom"
+              >
+                <Button
+                  icon={<CaretDoubleRight size={"16px"} />}
+                  className="addButtonLineSub"
+                  type="text"
+                >
+                  Agregar cliente
+                </Button>
+              </Popover>
+            )}
+          </Flex>
         )}
       </Flex>
     </div>

--- a/src/components/atoms/DocumentClientBR/DocumentClientBR.tsx
+++ b/src/components/atoms/DocumentClientBR/DocumentClientBR.tsx
@@ -1,11 +1,12 @@
 import { Button, Flex, Popover, Spin, Typography } from "antd";
-import { CaretDoubleRight, X } from "phosphor-react";
+import { CaretRight, X, Plus } from "phosphor-react";
 
-import "./documentclientbr.scss";
 import { useClientTypes } from "@/hooks/useClientTypes";
 import { InputCreateClientType } from "@/components/atoms/inputs/InputCreateClientType/InputCreateClientType";
 import { DocumentCards } from "@/components/atoms/DocumentCards/DocumentCards";
-import { InputCreateDocument } from "../inputs/inputCreate/InputCreateDocument";
+import { InputCreateDocument } from "@/components/atoms/inputs/inputCreate/InputCreateDocument";
+
+import "./documentclientbr.scss";
 
 const { Text } = Typography;
 
@@ -15,9 +16,6 @@ interface Props {
 
 export const DocumentClientBR = ({ isDisabledEdit }: Props) => {
   const { data, loading } = useClientTypes();
-  // const data = [];
-  // const loading = false;
-  console.log(data);
 
   return (
     <div className="contianerdocumentclientbr">
@@ -26,7 +24,7 @@ export const DocumentClientBR = ({ isDisabledEdit }: Props) => {
         {loading ? (
           <Spin />
         ) : (
-          <Flex className="documentclientbr" vertical>
+          <Flex className="documentclientbr" vertical gap={"0.5rem"}>
             {data?.map((document) => (
               <Flex className="clientTypeCard" vertical key={document.id}>
                 <Flex justify="space-between">
@@ -35,16 +33,16 @@ export const DocumentClientBR = ({ isDisabledEdit }: Props) => {
                     <Button icon={<X size={"16px"} />} className="removebutton" />
                   )}
                 </Flex>
-                <DocumentCards clientTypeId={document.id} />
+                <DocumentCards clientTypeId={document.id} isDisabledEdit={isDisabledEdit} />
 
                 {!isDisabledEdit && (
                   <Popover
-                    content={<InputCreateDocument isEditAvailable={false} />}
+                    content={<InputCreateDocument clientTypeId={document.id} />}
                     trigger="click"
                     placement="bottom"
                   >
                     <Button
-                      icon={<CaretDoubleRight size={"16px"} />}
+                      icon={<CaretRight size={"16px"} />}
                       className="addButtonLineSub"
                       type="text"
                     >
@@ -60,11 +58,7 @@ export const DocumentClientBR = ({ isDisabledEdit }: Props) => {
                 trigger="click"
                 placement="bottom"
               >
-                <Button
-                  icon={<CaretDoubleRight size={"16px"} />}
-                  className="addButtonLineSub"
-                  type="text"
-                >
+                <Button icon={<Plus size={"16px"} />} className="addButtonLineSub" type="text">
                   Agregar cliente
                 </Button>
               </Popover>

--- a/src/components/atoms/DocumentClientBR/documentclientbr.scss
+++ b/src/components/atoms/DocumentClientBR/documentclientbr.scss
@@ -24,7 +24,6 @@
         border: 1px solid $dark-gray;
         border-radius: 0.5rem;
         padding: 1rem;
-        margin-top: 1rem;
         &__title {
             font-size: 1rem;
         }
@@ -34,6 +33,11 @@
         align-items: center;
         color: $gray;
         margin-top: 0.5rem;
+        padding: 0;
+        span {
+            text-overflow: ellipsis;
+            overflow: hidden;
+        }
     }
 
     .removebutton {

--- a/src/components/atoms/DocumentClientBR/documentclientbr.scss
+++ b/src/components/atoms/DocumentClientBR/documentclientbr.scss
@@ -7,59 +7,33 @@
         font-size: 1rem;
         font-weight: 600;
         line-height: normal;
+        font-size: 1rem;
+        font-weight: 600;
+    }
+
+    .clientTypes {
+        background-color: $background;
+        padding: 0.75rem;
+        margin-top: 0.5rem;
+        border-radius: 0.5rem;
     }
 }
 .documentclientbr {
-    width: 100%;
-    background-color: $background;
-    padding: 1rem;
-    border-radius: 0.25rem;
-    margin-top: 1rem;
-
-    .lineBR {
+    .clientTypeCard {
         background-color: $white;
         border: 1px solid $dark-gray;
         border-radius: 0.5rem;
         padding: 1rem;
         margin-top: 1rem;
-    }
-
-    .titleLineBR {
-        font-size: 1.2rem;
-    }
-
-    .subtitleLineBR {
-        font-size: 1.1rem;
-    }
-
-    .mainSublinesBR {
-        flex-wrap: wrap;
-        margin-top: 1rem;
-        gap: 0.5rem;
-    }
-
-    .tagSubLineBR {
-        border: none;
-        display: flex;
-        align-items: center;
-        padding: 0.5rem;
-        background-color: $background;
-        font-weight: 500;
-        font-size: 0.9rem;
-        gap: 1.2rem;
+        &__title {
+            font-size: 1rem;
+        }
     }
     .addButtonLineSub {
         display: flex;
         align-items: center;
         color: $gray;
         margin-top: 0.5rem;
-    }
-
-    .buttonTextDocument {
-        padding: 0;
-        display: flex;
-        align-items: center;
-        text-decoration: underline;
     }
 
     .removebutton {

--- a/src/components/atoms/DocumentClientBR/documentclientbr.scss
+++ b/src/components/atoms/DocumentClientBR/documentclientbr.scss
@@ -3,7 +3,10 @@
 .contianerdocumentclientbr {
     margin-top: 2rem;
     .title {
-        font-size: 1.2rem;
+        color: var(--Black, #141414);
+        font-size: 1rem;
+        font-weight: 600;
+        line-height: normal;
     }
 }
 .documentclientbr {
@@ -45,7 +48,6 @@
         font-size: 0.9rem;
         gap: 1.2rem;
     }
-
     .addButtonLineSub {
         display: flex;
         align-items: center;

--- a/src/components/atoms/inputs/InputCreateChannel/inputcreatechannel.scss
+++ b/src/components/atoms/inputs/InputCreateChannel/inputcreatechannel.scss
@@ -3,7 +3,6 @@
 .inputcreatezone {
     background-color: $background;
     width: 100%;
-
     .createButtonZone {
         width: 98%;
         display: flex;

--- a/src/components/atoms/inputs/InputCreateClientType/InputCreateClientType.tsx
+++ b/src/components/atoms/inputs/InputCreateClientType/InputCreateClientType.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { Button, message } from "antd";
+import { useForm } from "react-hook-form";
+
+import { InputForm } from "../InputForm/InputForm";
+
+import "./inputCreateClientType.scss";
+import { useClientTypes } from "@/hooks/useClientTypes";
+
+export type ChannelType = {
+  channel: string;
+};
+interface Props {
+  isEditAvailable: boolean;
+}
+export const InputCreateClientType = ({ isEditAvailable = false }: Props) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const { addClient } = useClientTypes();
+  const [messageApi, contextHolder] = message.useMessage();
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+    reset
+  } = useForm<{ clientType: string }>({
+    defaultValues: { clientType: "" },
+    disabled: !isEditAvailable
+  });
+  const onSubmit = async (data: { clientType: string }) => {
+    setIsLoading(true);
+    await addClient(data.clientType, messageApi);
+    reset();
+    setIsLoading(false);
+  };
+  return (
+    <>
+      {contextHolder}
+      <form className="inputCreateClientType" onSubmit={handleSubmit(onSubmit)}>
+        <InputForm
+          titleInput=""
+          control={control}
+          nameInput="clientType"
+          error={errors.clientType}
+          customStyle={{
+            width: "96%",
+            backgroundColor: "transparent !important",
+            border: "1px solid white",
+            borderRadius: ".8rem"
+          }}
+          placeholder="Ingresar tipo de cliente"
+        />
+        <Button htmlType="submit" loading={isLoading} className="createButton">
+          Crear{" "}
+        </Button>
+      </form>
+    </>
+  );
+};

--- a/src/components/atoms/inputs/InputCreateClientType/inputCreateClientType.scss
+++ b/src/components/atoms/inputs/InputCreateClientType/inputCreateClientType.scss
@@ -1,0 +1,15 @@
+@import "@/styles/variables.scss";
+
+.inputCreateClientType {
+    background-color: $background;
+    width: 100%;
+
+    .createButton {
+        width: 98%;
+        display: flex;
+        align-items: center;
+        height: 3rem;
+        margin-top: 0.3rem;
+        border: none;
+    }
+}

--- a/src/components/atoms/inputs/InputForm/InputForm.tsx
+++ b/src/components/atoms/inputs/InputForm/InputForm.tsx
@@ -14,6 +14,7 @@ interface Props {
   hiddenTitle?: boolean;
   placeholder?: string;
   disabled?: boolean;
+  className?: string;
 }
 
 export const InputForm = ({

--- a/src/components/atoms/inputs/InputForm/inputform.scss
+++ b/src/components/atoms/inputs/InputForm/inputform.scss
@@ -35,6 +35,7 @@
         padding: 0.7rem;
         border-radius: 0.25rem;
         font-size: 1rem;
+        font-weight: 300;
 
         &::placeholder {
             color: $dark-gray !important;

--- a/src/components/atoms/inputs/inputCreate/InputCreateDocument.tsx
+++ b/src/components/atoms/inputs/inputCreate/InputCreateDocument.tsx
@@ -5,7 +5,8 @@ import { useForm } from "react-hook-form";
 import { InputForm } from "../InputForm/InputForm";
 import { useStructureBR } from "@/hooks/useBusinessRules";
 
-import "./inputcreatechannel.scss";
+import "./inputcreatedocument.scss";
+import { FileArrowUp } from "phosphor-react";
 
 export type ChannelType = {
   channel: string;
@@ -13,7 +14,7 @@ export type ChannelType = {
 interface Props {
   isEditAvailable: boolean;
 }
-export const InputCreateChannel = ({ isEditAvailable = false }: Props) => {
+export const InputCreateDocument = ({ isEditAvailable = false }: Props) => {
   const [isLoading, setIsLoading] = useState(false);
   const { addChannel } = useStructureBR();
   const [messageApi, contextHolder] = message.useMessage();
@@ -41,15 +42,11 @@ export const InputCreateChannel = ({ isEditAvailable = false }: Props) => {
           control={control}
           nameInput="channel"
           error={errors.channel}
-          customStyle={{
-            width: "96%",
-            backgroundColor: "transparent !important",
-            borderRadius: ".8rem"
-          }}
-          placeholder="Ingresar nombre del canal"
+          placeholder="Ingresar nombre del documento"
         />
         <Button htmlType="submit" loading={isLoading} className="createButtonZone">
-          Crear{" "}
+          <FileArrowUp size={16} />
+          Cargar plantilla
         </Button>
       </form>
     </>

--- a/src/components/atoms/inputs/inputCreate/inputcreatedocument.scss
+++ b/src/components/atoms/inputs/inputCreate/inputcreatedocument.scss
@@ -1,0 +1,24 @@
+@import '../../../../styles/variables.scss';
+
+.inputcreatezone {
+    background-color: $background;
+    width: 100%;
+
+		.createDocument {
+			width: 96%;
+			border-radius: .8rem;
+			border: 1px solid white;
+			background-color: transparent;
+		}
+
+    .createButtonZone {
+			gap: 10px;
+			width: 98%;
+			height: 3rem;
+			border: none;
+			display: flex;
+			margin-top: .3rem;
+			align-items: center;
+			justify-content: center;
+    }
+}

--- a/src/components/atoms/inputs/inputCreate/inputcreatedocument.scss
+++ b/src/components/atoms/inputs/inputCreate/inputcreatedocument.scss
@@ -1,24 +1,55 @@
-@import '../../../../styles/variables.scss';
+@import "@styles/variables.scss";
 
-.inputcreatezone {
+.inputCreateDocument {
     background-color: $background;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
     width: 100%;
+    min-width: 15rem;
 
-		.createDocument {
-			width: 96%;
-			border-radius: .8rem;
-			border: 1px solid white;
-			background-color: transparent;
-		}
+    &__check {
+        font-size: 1rem !important;
+        font-weight: 300;
+        color: $dark-gray;
+    }
 
-    .createButtonZone {
-			gap: 10px;
-			width: 98%;
-			height: 3rem;
-			border: none;
-			display: flex;
-			margin-top: .3rem;
-			align-items: center;
-			justify-content: center;
+    .createDocument {
+        width: 96%;
+        border-radius: 0.8rem;
+        border: 1px solid white;
+        background-color: transparent;
+    }
+
+    .uploadDocumentButton {
+        width: 100%;
+        height: 2.5rem;
+
+        .ant-upload-select {
+            width: 100%;
+            height: 100%;
+        }
+
+        button {
+            width: 100%;
+            height: 100%;
+            border: none;
+            font-weight: 300;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.4rem;
+        }
+    }
+
+    .createButton {
+        gap: 10px;
+        width: 100%;
+        height: 3rem;
+        font-weight: 300;
+        border: none;
+        display: flex;
+        align-items: center;
+        justify-content: center;
     }
 }

--- a/src/components/molecules/selects/SelectDocumentsByClientBR/selectzonebr.scss
+++ b/src/components/molecules/selects/SelectDocumentsByClientBR/selectzonebr.scss
@@ -12,7 +12,7 @@
     }
 
     .title {
-        font-size: 1.2rem;
+        font-size: 1rem;
     }
 
     .zone {

--- a/src/components/molecules/selects/SelectHoldingBR/selectholdingbr.scss
+++ b/src/components/molecules/selects/SelectHoldingBR/selectholdingbr.scss
@@ -11,7 +11,10 @@
     }
 
     .title {
-        font-size: 1.2rem;
+        font-size: 1rem;
+        font-weight: 600;
+        line-height: normal;
+        color: var(--Black, #141414);
     }
     .holdingsItems{
         overflow-y: auto;

--- a/src/components/molecules/selects/SelectStructure/SelectStructure.tsx
+++ b/src/components/molecules/selects/SelectStructure/SelectStructure.tsx
@@ -54,7 +54,7 @@ export const SelectStructure = ({
 
   return (
     <div className="selectstructure">
-      <Typography.Text className="title">Estructura</Typography.Text>
+      <Typography.Text className="title">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</Typography.Text>
       <Flex className="structure" gap={"1rem"}>
         {isLoading ? (
           <Spin />

--- a/src/components/molecules/selects/SelectStructureBR/selectstructurebr.scss
+++ b/src/components/molecules/selects/SelectStructureBR/selectstructurebr.scss
@@ -13,7 +13,7 @@
     }
 
     .title {
-        font-size: 1.2rem;
+        font-size: 1rem;
     }
     .holdingsItems{
         max-height: 550px;

--- a/src/components/molecules/selects/SelectZone/selectzone.scss
+++ b/src/components/molecules/selects/SelectZone/selectzone.scss
@@ -9,7 +9,7 @@
         margin-top: .5rem;
     }
     .title{
-        font-size: 1.2rem;
+        font-size: 1rem;
     }
     .zone{
         background-color: $white;

--- a/src/components/molecules/selects/SelectZoneBR/selectzonebr.scss
+++ b/src/components/molecules/selects/SelectZoneBR/selectzonebr.scss
@@ -17,7 +17,10 @@
     }
 
     .title {
-        font-size: 1.2rem;
+        font-size: 1rem;
+        font-weight: 600;
+        line-height: normal;
+        color: var(--Black, #141414);
     }
 
     .zone {

--- a/src/components/molecules/selects/clients/SelectClientTypes/SelectClientTypes.tsx
+++ b/src/components/molecules/selects/clients/SelectClientTypes/SelectClientTypes.tsx
@@ -1,12 +1,10 @@
 import { Select, Typography } from "antd";
-import useSWR from "swr";
 
-import { fetcher } from "@/utils/api/api";
-import { IClientTypes } from "@/types/clientTypes/clientTypes";
 import { ControllerRenderProps, FieldError } from "react-hook-form";
 import { ClientFormType } from "@/types/clients/IClients";
 
 import "../commonInputStyles.scss";
+import { useClientTypes } from "@/hooks/useClientTypes";
 
 interface Props {
   errors: FieldError | undefined;
@@ -14,14 +12,14 @@ interface Props {
 }
 const { Option } = Select;
 export const SelectClientTypes = ({ errors, field }: Props) => {
-  const { data, isLoading } = useSWR<IClientTypes>("/client/types", fetcher, {});
-  const options = data?.data;
+  const { data, loading } = useClientTypes();
+  const options = data;
   return (
     <>
       <Select
         placeholder="Seleccione Tipo de Documento"
         className={errors ? "selectInputError" : "selectInputCustom"}
-        loading={isLoading}
+        loading={loading}
         variant="borderless"
         optionLabelProp="label"
         {...field}

--- a/src/components/molecules/tables/ShipToProjectTable/ShipToProjectTable.tsx
+++ b/src/components/molecules/tables/ShipToProjectTable/ShipToProjectTable.tsx
@@ -127,16 +127,5 @@ const data = [
     subline: "Analgesicos",
     zone: "Norte",
     heritage: "Si"
-  },
-  {
-    key: "2",
-    active: "",
-    id: "31223",
-    city: "metrallo",
-    channel: "Institucional",
-    line: "Medicamentos",
-    subline: "Analgesicos",
-    zone: "Norte",
-    heritage: "Si"
   }
 ];

--- a/src/hooks/useClientTypes.ts
+++ b/src/hooks/useClientTypes.ts
@@ -1,0 +1,20 @@
+import { addClientType } from "@/services/clientTypes/clientTypes";
+import { IClientTypes } from "@/types/clientTypes/clientTypes";
+import { fetcher } from "@/utils/api/api";
+import { MessageInstance } from "antd/es/message/interface";
+import useSWR from "swr";
+
+export const useClientTypes = () => {
+  const { data, isLoading, mutate } = useSWR<IClientTypes>("/client/types", fetcher);
+
+  const addClient = async (clientTypeName: string, messageApi: MessageInstance) => {
+    await addClientType(clientTypeName, messageApi);
+    mutate();
+  };
+
+  return {
+    data: data?.data,
+    loading: isLoading,
+    addClient
+  };
+};

--- a/src/hooks/useClientTypes.ts
+++ b/src/hooks/useClientTypes.ts
@@ -1,4 +1,4 @@
-import { addClientType } from "@/services/clientTypes/clientTypes";
+import { addClientType, addDocumentsClientType } from "@/services/clientTypes/clientTypes";
 import { IClientTypes } from "@/types/clientTypes/clientTypes";
 import { fetcher } from "@/utils/api/api";
 import { MessageInstance } from "antd/es/message/interface";
@@ -12,9 +12,15 @@ export const useClientTypes = () => {
     mutate();
   };
 
+  const addDocument = async (formData: FormData, messageApi: MessageInstance) => {
+    await addDocumentsClientType(formData, messageApi);
+    mutate();
+  };
+
   return {
     data: data?.data,
     loading: isLoading,
-    addClient
+    addClient,
+    addDocument
   };
 };

--- a/src/hooks/useDocumentByClient.ts
+++ b/src/hooks/useDocumentByClient.ts
@@ -2,13 +2,12 @@ import useSWR from "swr";
 import { IDocumentsByClientId } from "@/types/documentsByClientId/IDocumentsByClientId";
 import { fetcher } from "@/utils/api/api";
 
-export const useDocumentByClient = () => {
+export const useDocumentByClient = (clientTypeId: number) => {
   const { data, isLoading } = useSWR<IDocumentsByClientId>(
-    `/client/documents/bytype/2`,
+    `/client/documents/bytype/${clientTypeId}`,
     fetcher,
     {}
   );
-  console.log(data);
 
   return {
     data,

--- a/src/services/clientTypes/clientTypes.ts
+++ b/src/services/clientTypes/clientTypes.ts
@@ -4,7 +4,6 @@ import { getIdToken } from "@/utils/api/api";
 
 import { SUCCESS } from "@/utils/constants/globalConstants";
 import { MessageInstance } from "antd/es/message/interface";
-import { ICreateDocumentByClient } from "@/types/clientTypes/clientTypes";
 
 export const addClientType = async (name: string, messageApi: MessageInstance) => {
   const token = await getIdToken();
@@ -38,26 +37,7 @@ export const addClientType = async (name: string, messageApi: MessageInstance) =
   }
 };
 
-export const addDocumentsClientType = async () => {
-  const modelData: ICreateDocumentByClient = {
-    client_type: 4,
-    required: 1,
-    document_name: "ddd",
-    template: undefined
-  };
-
-  const formData = new FormData();
-  // Agregar los campos del modelo de datos al objeto FormData
-  Object.keys(modelData).forEach((key) => {
-    if (modelData[key] !== undefined && modelData[key] !== null && modelData[key] !== "") {
-      if (modelData[key] instanceof File) {
-        formData.append("documents", modelData[key]);
-      } else {
-        formData.append(key, modelData[key]);
-      }
-    }
-  });
-
+export const addDocumentsClientType = async (formData: FormData, messageApi: MessageInstance) => {
   const token = await getIdToken();
 
   try {
@@ -71,10 +51,20 @@ export const addDocumentsClientType = async () => {
         }
       }
     );
-
+    if (response.status === SUCCESS) {
+      messageApi.open({
+        type: "success",
+        content: "Tipo de Documento creado exitosamente."
+      });
+    } else {
+      messageApi.open({
+        type: "error",
+        content: "Oops ocurrio un error creando tipo de documento."
+      });
+    }
     return response;
   } catch (error) {
-    console.log("Error creating new client: ", error);
+    console.log("Error creando tipo de documento: ", error);
     return error as AxiosError;
   }
 };

--- a/src/services/clientTypes/clientTypes.ts
+++ b/src/services/clientTypes/clientTypes.ts
@@ -1,0 +1,80 @@
+import axios, { AxiosError, AxiosResponse } from "axios";
+import config from "@/config";
+import { getIdToken } from "@/utils/api/api";
+
+import { SUCCESS } from "@/utils/constants/globalConstants";
+import { MessageInstance } from "antd/es/message/interface";
+import { ICreateDocumentByClient } from "@/types/clientTypes/clientTypes";
+
+export const addClientType = async (name: string, messageApi: MessageInstance) => {
+  const token = await getIdToken();
+
+  try {
+    const response: AxiosResponse = await axios.post(
+      `${config.API_HOST}/client/types`,
+      { name },
+      {
+        headers: {
+          Accept: "application/json, text/plain, */*",
+          "Content-Type": "application/json; charset=utf-8",
+          Authorization: `Bearer ${token}`
+        }
+      }
+    );
+    if (response.status === SUCCESS) {
+      messageApi.open({
+        type: "success",
+        content: `Tipo de  fue cliente creado exitosamente.`
+      });
+    } else {
+      messageApi.open({
+        type: "error",
+        content: "Oops ocurrio un error."
+      });
+    }
+    return response;
+  } catch (error) {
+    return error as any;
+  }
+};
+
+export const addDocumentsClientType = async () => {
+  const modelData: ICreateDocumentByClient = {
+    client_type: 4,
+    required: 1,
+    document_name: "ddd",
+    template: undefined
+  };
+
+  const formData = new FormData();
+  // Agregar los campos del modelo de datos al objeto FormData
+  Object.keys(modelData).forEach((key) => {
+    if (modelData[key] !== undefined && modelData[key] !== null && modelData[key] !== "") {
+      if (modelData[key] instanceof File) {
+        formData.append("documents", modelData[key]);
+      } else {
+        formData.append(key, modelData[key]);
+      }
+    }
+  });
+
+  const token = await getIdToken();
+
+  try {
+    const response: AxiosResponse | AxiosError = await axios.post(
+      `${config.API_HOST}/client/documents`,
+      formData,
+      {
+        headers: {
+          Accept: "application/json, text/plain, */*",
+          Authorization: `Bearer ${token}`
+        }
+      }
+    );
+
+    return response;
+  } catch (error) {
+    console.log("Error creating new client: ", error);
+    return error as AxiosError;
+  }
+};

--- a/src/types/clientTypes/clientTypes.ts
+++ b/src/types/clientTypes/clientTypes.ts
@@ -16,3 +16,9 @@ export interface ICreateDocumentByClient {
   document_name: string;
   template?: File;
 }
+
+export interface ICreateDocumentForm {
+  required: boolean;
+  document_name: string;
+  template?: File;
+}

--- a/src/types/clientTypes/clientTypes.ts
+++ b/src/types/clientTypes/clientTypes.ts
@@ -8,3 +8,11 @@ export interface IClientType {
   id: number;
   clientType: string;
 }
+
+export interface ICreateDocumentByClient {
+  [key: string]: any;
+  client_type: number;
+  required: number;
+  document_name: string;
+  template?: File;
+}


### PR DESCRIPTION
Aquí va lo realizado en conjutno con Brayan para mejorar la vista de Reglas de negocio, ahora mismo ya van los estilos como en el Figma y ya se crean Tipos de Cliente y Documentos por tipo de cliente:
![image](https://github.com/alleycorpsur/profitline_front_ts_react-nextjs_web/assets/79395978/7b1f12fd-ba78-424c-8a05-8e7bbb707be2)
![image](https://github.com/alleycorpsur/profitline_front_ts_react-nextjs_web/assets/79395978/70e79ad7-9e46-4ef8-8593-e0fc3a6208f2)
Detalle crear Cliente
![image](https://github.com/alleycorpsur/profitline_front_ts_react-nextjs_web/assets/79395978/0a77a67f-8c4d-4c1d-959c-3c4ee5e51807)

Faltaría entonces el eliminar tipo de cliente y documentos de este cliente, que ya estamos en ello con David.
