### PR TITLE
Fix/cliens view table

### DIFF
--- a/src/components/organisms/Customers/ClientsViewTable/ClientsViewTable.tsx
+++ b/src/components/organisms/Customers/ClientsViewTable/ClientsViewTable.tsx
@@ -31,7 +31,10 @@ export const ClientsViewTable = () => {
 
   const { data, loading } = usePortfolios({ page: page });
 
-  const [isLoading, setIsLoading] = useState(false);
+  const [loadingOpenPortfolio, setLoadingOpenPortfolio] = useState({
+    isLoading: false,
+    loadingId: 0
+  });
 
   const onChangePage = (pagePagination: number) => {
     setPage(pagePagination);
@@ -112,9 +115,16 @@ export const ClientsViewTable = () => {
       render: (_, row: IClientsPortfolio) => (
         <Link href={`/clientes/detail/${row.client_id}/project/${row.project_id}`}>
           <Button
-            onClick={() => setIsLoading(true)}
+            key={row.client_id}
+            onClick={() => setLoadingOpenPortfolio({ isLoading: true, loadingId: row.client_id })}
             className="buttonSeeProject"
-            icon={isLoading ? <Spin /> : <Eye size={"1.3rem"} />}
+            icon={
+              loadingOpenPortfolio.loadingId === row.client_id && loadingOpenPortfolio.isLoading ? (
+                <Spin />
+              ) : (
+                <Eye size={"1.3rem"} />
+              )
+            }
           />
         </Link>
       )

--- a/src/components/organisms/Customers/ClientsViewTable/ClientsViewTable.tsx
+++ b/src/components/organisms/Customers/ClientsViewTable/ClientsViewTable.tsx
@@ -12,7 +12,6 @@ import {
   XCircle,
   MagnifyingGlassMinus
 } from "phosphor-react";
-import { useProjects } from "@/hooks/useProjects";
 import CardsClients from "../../../molecules/modals/CardsClients/CardsClients";
 import { usePortfolios } from "@/hooks/usePortfolios";
 import { IClientsPortfolio } from "@/types/clients/IViewClientsTable";
@@ -24,25 +23,15 @@ import "./ClientsViewTable.scss";
 const { Text } = Typography;
 
 export const ClientsViewTable = () => {
+  const [page, setPage] = useState(1);
   const { ID } = useAppStore((projects) => projects.selectProject);
   useEffect(() => {
     if (!ID) redirectModal();
   }, []);
 
-  const { data: clients } = usePortfolios();
+  const { data, loading } = usePortfolios({ page: page });
 
-  const [selectFilters] = useState({
-    country: [] as string[],
-    currency: [] as string[]
-  });
-  const [page, setPage] = useState(1);
   const [isLoading, setIsLoading] = useState(false);
-  const { loading, data } = useProjects({
-    page: selectFilters.country.length !== 0 || selectFilters.currency.length !== 0 ? 1 : page,
-    currencyId: selectFilters.currency,
-    countryId: selectFilters.country,
-    searchQuery: ""
-  });
 
   const onChangePage = (pagePagination: number) => {
     setPage(pagePagination);
@@ -145,49 +134,53 @@ export const ClientsViewTable = () => {
             <Col span={4}>
               <CardsClients
                 title={"Total cartera"}
-                total={clients?.grandTotal.total_wallet || 0}
+                total={data?.data?.grandTotal?.total_wallet || 0}
                 icon={<Money />}
               />
             </Col>
             <Col span={4}>
               <CardsClients
                 title={"C. vencida"}
-                total={clients?.grandTotal.total_past_due || 0}
+                total={data?.data?.grandTotal?.total_past_due || 0}
                 icon={<CalendarX />}
               />
             </Col>
             <Col span={4}>
               <CardsClients
                 title={"Presupuesto"}
-                total={clients?.grandTotal.total_budget || 0}
+                total={data?.data?.grandTotal?.total_budget || 0}
                 icon={<CalendarBlank />}
               />
             </Col>
             <Col span={4}>
               <CardsClients
                 title={"R. aplicado"}
-                total={clients?.grandTotal.applied_payments_ammount || 0}
+                total={data?.data?.grandTotal?.applied_payments_ammount || 0}
                 icon={<Receipt />}
               />
             </Col>
             <Col span={4}>
               <CardsClients
                 title={"Pagos no ap."}
-                total={clients?.grandTotal.unapplied_payments_ammount || 0}
+                total={data?.data?.grandTotal?.unapplied_payments_ammount || 0}
                 icon={<XCircle />}
               />
             </Col>
             <Col span={4}>
               <CardsClients
                 title={"Pagos no id."}
-                total={clients?.grandTotal.unidentified_payment_ammount || 0}
+                total={data?.data?.grandTotal?.unidentified_payment_ammount || 0}
                 icon={<MagnifyingGlassMinus />}
               />
             </Col>
           </Row>
         </Col>
         <Col span={3}>
-          <CardsClients title={"DSO"} total={clients?.grandTotal.dso || 0} icon={<Calendar />} />
+          <CardsClients
+            title={"DSO"}
+            total={data?.data?.grandTotal?.dso || 0}
+            icon={<Calendar />}
+          />
         </Col>
       </Row>
       <Table
@@ -195,11 +188,13 @@ export const ClientsViewTable = () => {
         scroll={{ y: "61dvh", x: undefined }}
         columns={columns as TableProps<any>["columns"]}
         pagination={{
-          pageSize: 25,
-          total: data.pagination.totalRows,
-          onChange: onChangePage
+          current: page,
+          pageSize: data?.pagination.rowsperpage,
+          total: data?.pagination?.totalRows,
+          onChange: onChangePage,
+          showSizeChanger: false
         }}
-        dataSource={clients?.clientsPortfolio.map((data) => ({ ...data, key: data.client_id }))}
+        dataSource={data?.data?.clientsPortfolio.map((data) => ({ ...data, key: data.client_id }))}
       />
     </main>
   );

--- a/src/hooks/usePortfolios.ts
+++ b/src/hooks/usePortfolios.ts
@@ -3,12 +3,16 @@ import { IViewClientsTable } from "@/types/clients/IViewClientsTable";
 import useSWR from "swr";
 import { useAppStore } from "@/lib/store/store";
 
-export const usePortfolios = () => {
+interface Props {
+  page?: number;
+}
+export const usePortfolios = ({ page }: Props) => {
   const { ID } = useAppStore((state) => state.selectProject);
-  const { data, isLoading } = useSWR<IViewClientsTable>(`/portfolio/client/project/${ID}`, fetcher);
+  const pathKey = `/portfolio/client/project/${ID}?page=${page}`;
+  const { data, isLoading } = useSWR<IViewClientsTable>(pathKey, fetcher);
 
   return {
-    data: data?.data,
+    data: data,
     loading: isLoading
   };
 };

--- a/src/hooks/usePortfolios.ts
+++ b/src/hooks/usePortfolios.ts
@@ -8,7 +8,8 @@ interface Props {
 }
 export const usePortfolios = ({ page }: Props) => {
   const { ID } = useAppStore((state) => state.selectProject);
-  const pathKey = `/portfolio/client/project/${ID}?page=${page}`;
+  const limit = 100;
+  const pathKey = `/portfolio/client/project/${ID}?page=${page}&limit=${limit}`;
   const { data, isLoading } = useSWR<IViewClientsTable>(pathKey, fetcher);
 
   return {


### PR DESCRIPTION
Van fixes pequeños, ahora debería funcionar como debe la tabla de portafolios, ya no hace la petición extra, el boton del ojo solo aparece en loading del cliente seleccionado y se agrega el mínimo de 100 filas por pagina de la tabla (pedido por Felipe).
Adjunto imagen de referencia
![image](https://github.com/user-attachments/assets/ad051a8f-0118-4931-ba4b-0ff1e730b7c0)
