### PR TITLE
fix: :bug: story677RemvoeCacheMadeByImageFormNextFixSomeStyles

### DIFF
--- a/src/components/atoms/DocumentButtonAction/DocumentButtonAction.tsx
+++ b/src/components/atoms/DocumentButtonAction/DocumentButtonAction.tsx
@@ -30,12 +30,10 @@ export const DocumentButtonAction = ({
 
   const handleDocumentClick = () => {
     const fileExtension = documentUrl?.trim().split(".").pop()?.toLowerCase() ?? "";
-    if (fileExtension === "pdf") {
-      window.open(documentUrl, "_blank");
-    } else if (["png", "jpg", "jpeg"].includes(fileExtension)) {
+    if (["png", "jpg", "jpeg"].includes(fileExtension)) {
       if (isModalOpen === false) setIsModalOpen(true);
     } else {
-      showMessage("error", "Formato de archivo no soportado");
+      window.open(documentUrl, "_blank");
     }
   };
 
@@ -44,6 +42,7 @@ export const DocumentButtonAction = ({
     if (editable) {
       const input = document.createElement("input");
       input.type = "file";
+      input.accept = "image/*, application/pdf";
       input.onchange = async (e: any) => {
         const file = e.target.files[0];
         setLoadingReplaceDocument(true);

--- a/src/components/atoms/UploadImg/UploadImg.tsx
+++ b/src/components/atoms/UploadImg/UploadImg.tsx
@@ -65,7 +65,8 @@ export const UploadImg = ({ disabled = false, imgDefault = "", setImgFile }: Pro
       >
         {loading && <Spin />}
         {imageUrl ? (
-          <Image src={imageUrl} alt="avatar" width={0} height={0} sizes="100vw" className="img" />
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={imageUrl} alt="avatar" className="img" />
         ) : (
           <Image src={"/images/watermark.svg"} alt="marca de agua" width={48} height={48} />
         )}

--- a/src/components/atoms/UploadImg/uploadimg.scss
+++ b/src/components/atoms/UploadImg/uploadimg.scss
@@ -1,11 +1,12 @@
 .uploadimg {
     margin-bottom: 1rem;
     .uploadText {
-			margin-top: .5rem;
-			color: #DDD;
+        margin-top: 0.5rem;
+        color: #ddd;
     }
     .img {
-			width: 100%;
-			height: 100%;
-	}
+        width: 100%;
+        height: 100%;
+        border-radius: 6px;
+    }
 }

--- a/src/components/molecules/SideBar/SideBar.tsx
+++ b/src/components/molecules/SideBar/SideBar.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
 import { Avatar, Button, Flex } from "antd";
-import Image from "next/image";
 
 import {
   ArrowLineRight,
@@ -46,12 +45,8 @@ export const SideBar = () => {
       <Flex vertical className="containerButtons">
         <button className="logoContainer" onClick={() => setModalProjectSelectorOpen(true)}>
           {LOGO ? (
-            <Image
-              width={isSideBarLarge ? 75 : 50}
-              height={isSideBarLarge ? 75 : 50}
-              alt="logo company"
-              src={LOGO.trim()}
-            />
+            // eslint-disable-next-line @next/next/no-img-element
+            <img alt="logo company" src={LOGO.trim()} className="logoContainer__image" />
           ) : (
             <Avatar shape="square" className="imageWithoutImage" size={50} icon={<Clipboard />} />
           )}

--- a/src/components/molecules/SideBar/sidebar.scss
+++ b/src/components/molecules/SideBar/sidebar.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/variables";
+@import "@styles/variables.scss";
 
 .main {
     width: 90px;
@@ -29,8 +29,11 @@
             transition: all 0.3s ease;
             border-radius: 8px;
 
-            img {
+            &__image {
                 border-radius: inherit;
+                width: 50px;
+                height: 50px;
+                object-fit: fill;
             }
 
             &:hover {

--- a/src/components/molecules/tabs/Projects/ClientProjectForm/ClientProjectForm.tsx
+++ b/src/components/molecules/tabs/Projects/ClientProjectForm/ClientProjectForm.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import { useParams } from "next/navigation";
-import { Button, Col, Flex, Input, Row, Spin, Typography } from "antd";
+import { Button, Flex, Input, Spin, Typography } from "antd";
 import { Controller, useForm } from "react-hook-form";
 import { ArrowsClockwise, CaretLeft, Pencil, Plus } from "phosphor-react";
 

--- a/src/components/organisms/forms/LoginForm/loginform.scss
+++ b/src/components/organisms/forms/LoginForm/loginform.scss
@@ -1,5 +1,5 @@
 /* $layout-breakpoint-small: 960px; */
-@import "../../../../styles/variables";
+@import "@styles/variables.scss";
 
 .form {
     width: 95%;

--- a/src/components/organisms/projects/DetailProjectView/DetailProjectView.tsx
+++ b/src/components/organisms/projects/DetailProjectView/DetailProjectView.tsx
@@ -53,6 +53,7 @@ export const DetailsProjectView = ({ isEdit = false, idProjectParam = "" }: Prop
       const response = await updateProject(finalData, idProjectParam, data.UUID);
       if (response.status === SUCCESS) {
         showMessage("success", "El proyecto fue editado exitosamente.");
+        window.location.reload();
       }
       setIsEditProject(false);
     } catch (error) {


### PR DESCRIPTION
Va el fix para la historia [677](https://alleycorpsur.atlassian.net/browse/PROF-677), removí los componentes Image de Next por los elementos regulares img que no quedan en cache, para así evitar incongruencias cuando se edita la imagen de un proyecto o similar...
![image](https://github.com/user-attachments/assets/c5aefe14-c92a-4b35-9fe7-81ae4a3ff424)
También envio el fix del bug [518](https://alleycorpsur.atlassian.net/browse/PROF-518) que es acerca de editar el documento de un cliente, ya dejaba editar pero en ocasiones no se podía abrir.