### PR TITLE
fix: :ambulance: questionMarkForNullSafetyCrashingDeploy

### DIFF
--- a/src/components/molecules/modals/ModalProjectSelector/ModalProjectSelector.tsx
+++ b/src/components/molecules/modals/ModalProjectSelector/ModalProjectSelector.tsx
@@ -41,7 +41,7 @@ export const ModalProjectSelector = ({ isOpen, onClose }: Props) => {
       }
     };
 
-    if (projects.length === 0) {
+    if (projects?.length === 0) {
       fetchProjects();
     }
   }, []);
@@ -60,7 +60,7 @@ export const ModalProjectSelector = ({ isOpen, onClose }: Props) => {
     onClose();
   };
 
-  if (projects.length > 1) {
+  if (projects?.length > 1) {
     return (
       <Modal
         className="modalProjectSelector"


### PR DESCRIPTION
Se rompía el proyecto sino llegaban proyectos en un endpoint, argegué la interrogacion para null safety.