### PR TITLE
feat: Update IVA label in CreateOrderCart component

### DIFF
--- a/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
+++ b/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
@@ -132,7 +132,7 @@ const CreateOrderCart: FC = ({}) => {
               <p>{formatMoney(confirmOrderData?.subtotal)}</p>
             </Flex>
             <Flex justify="space-between">
-              <p>IVA 19%</p>
+              <p>IVA</p>
               <p>{formatMoney(confirmOrderData?.taxes)}</p>
             </Flex>
             <Flex justify="space-between">


### PR DESCRIPTION
Va el fix para que ya no aparezca "IVA 19%" quemado en el front, ahora solo dice "IVA", solucionando el bug [703](https://alleycorpsur.atlassian.net/browse/PROF-703)