### PR TITLE
Feat/add history tab

### DIFF
--- a/src/components/molecules/modals/ModalConfirmAction/ModalConfirmAction.tsx
+++ b/src/components/molecules/modals/ModalConfirmAction/ModalConfirmAction.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Modal } from "antd";
+
+import "./modalConfirmAction.scss";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  onOk?: () => void;
+  title: string;
+  content?: React.ReactNode;
+}
+export const ModalConfirmAction = ({ isOpen, onClose, onOk, title, content }: Props) => {
+  return (
+    <Modal
+      className="ModalConfirmAction"
+      width={"60%"}
+      open={isOpen}
+      onCancel={onClose}
+      okButtonProps={{ className: "acceptButton" }}
+      okText="Aceptar"
+      cancelButtonProps={{
+        className: "cancelButton"
+      }}
+      title={title}
+      onOk={onOk}
+    >
+      {content}
+    </Modal>
+  );
+};

--- a/src/components/molecules/modals/ModalConfirmAction/modalConfirmAction.scss
+++ b/src/components/molecules/modals/ModalConfirmAction/modalConfirmAction.scss
@@ -1,0 +1,55 @@
+@import "@styles/variables.scss";
+
+.ModalConfirmAction {
+    .ant-modal-content,
+    .ant-modal-header {
+        background-color: $white !important;
+        text-align: center;
+    }
+
+    .ant-modal-body {
+        margin: 1.5rem auto;
+    }
+
+    .ant-modal-title {
+        font-size: 1.3rem !important;
+    }
+
+    .ant-modal-footer {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 10px;
+    }
+
+    .acceptButton {
+        color: black;
+        width: 100%;
+        height: 2.5rem;
+        font-size: 0.9rem;
+        font-weight: 500;
+        background-color: $secondary;
+        box-shadow: none;
+        margin: 0px !important;
+
+        &:hover {
+            opacity: 0.8;
+            box-shadow: none;
+            background-color: $secondary !important;
+        }
+    }
+
+    .cancelButton {
+        width: 100%;
+        height: 2.5rem;
+        box-shadow: none;
+        background-color: $white;
+        color: black;
+        font-weight: 600;
+        border: 1px solid black;
+
+        &:hover {
+            background-color: $white !important;
+            opacity: 0.8;
+        }
+    }
+}

--- a/src/components/molecules/tables/UsersProjectTable/UsersProjectTable.tsx
+++ b/src/components/molecules/tables/UsersProjectTable/UsersProjectTable.tsx
@@ -273,7 +273,6 @@ export const UsersProjectTable: React.FC<Props> = ({
       <main className="mainUsersProjectTable">
         <Flex justify="space-between" className="mainUsersProjectTable_header">
           <Flex gap={"0.625rem"} align="center">
-            {/* create a input for search  */}
             <UiSearchInput
               placeholder="Buscar usuarios"
               onChange={(e) => setSearchQuery(e.target.value)}

--- a/src/modules/clients/components/contacts-tab-table/contacts-tab-table.tsx
+++ b/src/modules/clients/components/contacts-tab-table/contacts-tab-table.tsx
@@ -7,7 +7,7 @@ import useScreenHeight from "@/components/hooks/useScreenHeight";
 import "./contacts-tab-table.scss";
 const { Text } = Typography;
 
-interface PropsInvoicesTable {
+interface PropsContactsTable {
   dataAllContacts: IContact[];
   setSelectedRows: Dispatch<SetStateAction<IContact[] | undefined>>;
   setShowContactModal: Dispatch<
@@ -22,7 +22,7 @@ const ContactsTable = ({
   dataAllContacts: data,
   setSelectedRows,
   setShowContactModal
-}: PropsInvoicesTable) => {
+}: PropsContactsTable) => {
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
   const [page, setPage] = useState(1);
   const height = useScreenHeight();

--- a/src/modules/clients/components/history-tab-table/history-tab-table.scss
+++ b/src/modules/clients/components/history-tab-table/history-tab-table.scss
@@ -1,0 +1,51 @@
+@import "@styles/variables.scss";
+
+.historyTable {
+    margin-top: 1rem;
+
+    .ant-table-column-title {
+        font-size: 1rem;
+        margin: 0.5rem 0;
+    }
+
+    .ant-table-tbody {
+        overflow-x: hidden;
+
+        &-virtual-scrollbar-horizontal {
+            display: none;
+        }
+    }
+
+    .ant-table-container {
+        table {
+            .ant-table-cell {
+                padding-top: 0.4rem;
+                padding-bottom: 0.4rem;
+            }
+        }
+    }
+
+    .cell {
+        display: inline-block;
+    }
+
+    .eyeButton {
+        background-color: $background;
+
+        &:hover {
+            background-color: $dark-gray !important;
+        }
+    }
+
+    .pagination {
+        justify-content: center;
+    }
+
+    .next {
+        transform: rotate(90deg);
+    }
+
+    .prev {
+        transform: rotate(-90deg);
+    }
+}

--- a/src/modules/clients/components/history-tab-table/history-tab-table.scss
+++ b/src/modules/clients/components/history-tab-table/history-tab-table.scss
@@ -31,6 +31,8 @@
 
     .eyeButton {
         background-color: $background;
+        width: 2rem;
+        aspect-ratio: 1/1;
 
         &:hover {
             background-color: $dark-gray !important;
@@ -47,5 +49,26 @@
 
     .prev {
         transform: rotate(-90deg);
+    }
+}
+
+.tooltipHistoryOptions {
+    .ant-tooltip-inner {
+        padding: 0.75rem !important;
+    }
+}
+
+.tooltipButton {
+    width: 100%;
+    background-color: $background !important;
+    border: none !important;
+    padding: 0.5rem 0.625rem !important;
+    padding-top: 0.6rem !important;
+    display: flex !important;
+    justify-content: left !important;
+    align-items: center !important;
+
+    &:hover {
+        background-color: $dark-gray !important;
     }
 }

--- a/src/modules/clients/components/history-tab-table/history-tab-table.tsx
+++ b/src/modules/clients/components/history-tab-table/history-tab-table.tsx
@@ -1,0 +1,103 @@
+import { useState } from "react";
+import { Button, Flex, Table, TableProps, Typography } from "antd";
+import { DotsThree, Paperclip, Triangle } from "phosphor-react";
+import useScreenHeight from "@/components/hooks/useScreenHeight";
+
+import "./history-tab-table.scss";
+import { IHistoryRecord } from "../../containers/history-tab/history-tab";
+const { Text } = Typography;
+
+interface PropsHistoryTable {
+  dataAllRecords: IHistoryRecord[];
+}
+
+const HistoryTable = ({ dataAllRecords: data }: PropsHistoryTable) => {
+  const [page, setPage] = useState(1);
+  const height = useScreenHeight();
+
+  const onChangePage = (pagePagination: number) => {
+    setPage(pagePagination);
+  };
+
+  const columns: TableProps<IHistoryRecord>["columns"] = [
+    {
+      title: "Fecha",
+      dataIndex: "create_at",
+      key: "create_at",
+      render: (create_at) => <Text className="cell">{create_at}</Text>,
+      sorter: (a, b) => a.create_at.localeCompare(b.create_at),
+      showSorterTooltip: false
+    },
+    {
+      title: "Evento",
+      dataIndex: "event",
+      key: "event",
+      render: (text) => <Text className="cell">{text}</Text>,
+      sorter: (a, b) => a.event.localeCompare(b.event),
+      showSorterTooltip: false
+    },
+    {
+      title: "Descripción",
+      key: "payment_amount",
+      dataIndex: "payment_amount",
+      render: (payment_amount, row) => (
+        <Text className="cell">
+          Pago #{row.payment_id} por {payment_amount}
+        </Text>
+      ),
+      sorter: (a, b) => a.payment_amount - b.payment_amount,
+      showSorterTooltip: false
+      // width: 140
+    },
+    {
+      title: "Usuario",
+      key: "user",
+      dataIndex: "user",
+      render: (text) => <Text className="cell">{text}</Text>,
+      sorter: (a, b) => a.user.localeCompare(b.user),
+      showSorterTooltip: false
+      // width: 140
+    },
+    {
+      title: "",
+      render: (_, record) => (
+        <Flex gap="0.5rem">
+          <Button className="eyeButton" icon={<Paperclip size={"1.2rem"} />} />
+          <Button className="eyeButton" icon={<DotsThree size={"1.2rem"} />} />
+        </Flex>
+      ),
+      width: 80
+    }
+  ];
+
+  return (
+    <>
+      <Table
+        className="historyTable"
+        columns={columns}
+        dataSource={data?.map((data) => ({ ...data, key: data.id }))}
+        // rowSelection={false}
+        virtual
+        scroll={{ y: height - 400, x: 100 }}
+        pagination={{
+          current: page,
+          showSizeChanger: false,
+          position: ["none", "bottomRight"],
+          onChange: onChangePage,
+          itemRender: (page, type, originalElement) => {
+            if (type === "prev") {
+              return <Triangle size={".75rem"} weight="fill" className="prev" />;
+            } else if (type === "next") {
+              return <Triangle size={".75rem"} weight="fill" className="next" />;
+            } else if (type === "page") {
+              return <Flex className="pagination">{page}</Flex>;
+            }
+            return originalElement;
+          }
+        }}
+      />
+    </>
+  );
+};
+
+export default HistoryTable;

--- a/src/modules/clients/components/history-tab-table/history-tab-table.tsx
+++ b/src/modules/clients/components/history-tab-table/history-tab-table.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { Button, Flex, Table, TableProps, Typography } from "antd";
-import { DotsThree, Paperclip, Triangle } from "phosphor-react";
+import { Button, Flex, Table, TableProps, Tooltip, Typography } from "antd";
+import { DotsThreeVertical, DownloadSimple, Paperclip, Trash, Triangle } from "phosphor-react";
 import useScreenHeight from "@/components/hooks/useScreenHeight";
 
 import "./history-tab-table.scss";
@@ -18,6 +18,24 @@ const HistoryTable = ({ dataAllRecords: data }: PropsHistoryTable) => {
   const onChangePage = (pagePagination: number) => {
     setPage(pagePagination);
   };
+
+  const tootlTipOptions = [
+    {
+      title: "PDF",
+      icon: <DownloadSimple size={"1.2rem"} />,
+      onClick: () => console.info("PDF")
+    },
+    {
+      title: "Excel",
+      icon: <DownloadSimple size={"1.2rem"} />,
+      onClick: () => console.info("Excel")
+    },
+    {
+      title: "Anular aplicación",
+      icon: <Trash size={"1.2rem"} />,
+      onClick: () => console.info("Anular app")
+    }
+  ];
 
   const columns: TableProps<IHistoryRecord>["columns"] = [
     {
@@ -47,7 +65,6 @@ const HistoryTable = ({ dataAllRecords: data }: PropsHistoryTable) => {
       ),
       sorter: (a, b) => a.payment_amount - b.payment_amount,
       showSorterTooltip: false
-      // width: 140
     },
     {
       title: "Usuario",
@@ -56,17 +73,36 @@ const HistoryTable = ({ dataAllRecords: data }: PropsHistoryTable) => {
       render: (text) => <Text className="cell">{text}</Text>,
       sorter: (a, b) => a.user.localeCompare(b.user),
       showSorterTooltip: false
-      // width: 140
     },
     {
       title: "",
       render: (_, record) => (
         <Flex gap="0.5rem">
           <Button className="eyeButton" icon={<Paperclip size={"1.2rem"} />} />
-          <Button className="eyeButton" icon={<DotsThree size={"1.2rem"} />} />
+          <Tooltip
+            overlayClassName="tooltipHistoryOptions"
+            title={
+              <Flex vertical gap={"0.5rem"}>
+                {tootlTipOptions.map((option) => (
+                  <Button
+                    key={option.title}
+                    className="tooltipButton"
+                    icon={option.icon}
+                    onClick={option.onClick}
+                  >
+                    <p>{option.title}</p>
+                  </Button>
+                ))}
+              </Flex>
+            }
+            color={"white"}
+            key={record.id}
+          >
+            <Button className="eyeButton" icon={<DotsThreeVertical size={"1.2rem"} />} />
+          </Tooltip>
         </Flex>
       ),
-      width: 80
+      width: 100
     }
   ];
 
@@ -76,7 +112,6 @@ const HistoryTable = ({ dataAllRecords: data }: PropsHistoryTable) => {
         className="historyTable"
         columns={columns}
         dataSource={data?.map((data) => ({ ...data, key: data.id }))}
-        // rowSelection={false}
         virtual
         scroll={{ y: height - 400, x: 100 }}
         pagination={{

--- a/src/modules/clients/components/history-tab-table/history-tab-table.tsx
+++ b/src/modules/clients/components/history-tab-table/history-tab-table.tsx
@@ -1,10 +1,13 @@
 import { useState } from "react";
 import { Button, Flex, Table, TableProps, Tooltip, Typography } from "antd";
 import { DotsThreeVertical, DownloadSimple, Paperclip, Trash, Triangle } from "phosphor-react";
+
 import useScreenHeight from "@/components/hooks/useScreenHeight";
+import { IHistoryRecord } from "../../containers/history-tab/history-tab";
+import { ModalConfirmAction } from "@/components/molecules/modals/ModalConfirmAction/ModalConfirmAction";
 
 import "./history-tab-table.scss";
-import { IHistoryRecord } from "../../containers/history-tab/history-tab";
+
 const { Text } = Typography;
 
 interface PropsHistoryTable {
@@ -13,10 +16,20 @@ interface PropsHistoryTable {
 
 const HistoryTable = ({ dataAllRecords: data }: PropsHistoryTable) => {
   const [page, setPage] = useState(1);
+  const [isConfirmCancelModalOpen, setIsConfirmCancelModalOpen] = useState({
+    isOpen: false,
+    id: 0
+  });
+
   const height = useScreenHeight();
 
   const onChangePage = (pagePagination: number) => {
     setPage(pagePagination);
+  };
+
+  const handleCancelApplication = () => {
+    console.info("Anular aplicación con id", isConfirmCancelModalOpen.id);
+    setIsConfirmCancelModalOpen({ isOpen: false, id: 0 });
   };
 
   const tootlTipOptions = [
@@ -33,7 +46,7 @@ const HistoryTable = ({ dataAllRecords: data }: PropsHistoryTable) => {
     {
       title: "Anular aplicación",
       icon: <Trash size={"1.2rem"} />,
-      onClick: () => console.info("Anular app")
+      onClick: (recordId: number) => setIsConfirmCancelModalOpen({ isOpen: true, id: recordId })
     }
   ];
 
@@ -88,7 +101,7 @@ const HistoryTable = ({ dataAllRecords: data }: PropsHistoryTable) => {
                     key={option.title}
                     className="tooltipButton"
                     icon={option.icon}
-                    onClick={option.onClick}
+                    onClick={() => option.onClick(record.id)}
                   >
                     <p>{option.title}</p>
                   </Button>
@@ -130,6 +143,18 @@ const HistoryTable = ({ dataAllRecords: data }: PropsHistoryTable) => {
             return originalElement;
           }
         }}
+      />
+      <ModalConfirmAction
+        isOpen={isConfirmCancelModalOpen.isOpen}
+        onClose={() =>
+          setIsConfirmCancelModalOpen({
+            isOpen: false,
+            id: 0
+          })
+        }
+        title="¿Estás seguro que deseas anular esta apliación?"
+        content="Esta acción es definitiva"
+        onOk={handleCancelApplication}
       />
     </>
   );

--- a/src/modules/clients/components/history-tab-table/index.ts
+++ b/src/modules/clients/components/history-tab-table/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./history-tab-table";

--- a/src/modules/clients/containers/client-details/client-details.tsx
+++ b/src/modules/clients/containers/client-details/client-details.tsx
@@ -1,16 +1,19 @@
 import { CaretLeft } from "phosphor-react";
 import { Dispatch, FC, SetStateAction, createContext, useMemo, useState } from "react";
 import { Button, Flex, Spin } from "antd";
+import Link from "next/link";
+
+import { useClientDetails } from "../../hooks/client-details/client-details.hook";
 import { WalletTab } from "@/components/organisms/Customers/WalletTab/WalletTab";
 import Dashboard from "../dashboard";
 import InvoiceActionsModal from "../invoice-actions-modal";
-import { useClientDetails } from "../../hooks/client-details/client-details.hook";
-import Link from "next/link";
 import UiTab from "@/components/ui/ui-tab";
 import { InvoiceAction } from "../../constants/invoice-actions.constants";
 import AccountingAdjustmentsTab from "../accounting-adjustments-tab";
 import PaymentsTab from "@/modules/clients/containers/payments-tab";
 import ContactsTab from "../contacts-tab";
+import HistoryTab from "../history-tab";
+
 import { IDataSection } from "@/types/portfolios/IPortfolios";
 
 import styles from "./client-details.module.scss";
@@ -69,6 +72,11 @@ export const ClientDetails: FC<ClientDetailsProps> = () => {
       key: "5",
       label: "Contactos",
       children: <ContactsTab />
+    },
+    {
+      key: "6",
+      label: "Historial",
+      children: <HistoryTab />
     }
   ];
 

--- a/src/modules/clients/containers/history-tab/history-tab.scss
+++ b/src/modules/clients/containers/history-tab/history-tab.scss
@@ -1,0 +1,1 @@
+@import "@styles/variables.scss";

--- a/src/modules/clients/containers/history-tab/history-tab.tsx
+++ b/src/modules/clients/containers/history-tab/history-tab.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import { Flex, Spin } from "antd";
+
+import UiSearchInput from "@/components/ui/search-input";
+import { DotsDropdown } from "@/components/atoms/DotsDropdown/DotsDropdown";
+import UiFilterDropdown from "@/components/ui/ui-filter-dropdown";
+import HistoryTable from "../../components/history-tab-table";
+
+import "./history-tab.scss";
+
+const HistoryTab = () => {
+  const [search, setSearch] = useState("");
+  const isLoading = false;
+
+  return (
+    <>
+      {isLoading ? (
+        <Flex justify="center" align="center" style={{ height: "3rem" }}>
+          <Spin />
+        </Flex>
+      ) : (
+        <div className="historyTab">
+          <Flex justify="space-between" className="historyTab__header">
+            <Flex gap={"0.5rem"}>
+              <UiSearchInput
+                className="search"
+                placeholder="Buscar"
+                onChange={(event) => {
+                  setTimeout(() => {
+                    setSearch(event.target.value);
+                  }, 1000);
+                }}
+              />
+              <UiFilterDropdown />
+              <DotsDropdown />
+            </Flex>
+          </Flex>
+          <HistoryTable dataAllRecords={mockData} />
+        </div>
+      )}
+    </>
+  );
+};
+
+export default HistoryTab;
+
+export interface IHistoryRecord {
+  id: number;
+  create_at: string;
+  event: string;
+  payment_id: number;
+  payment_amount: number;
+  user: string;
+}
+
+const mockData = [
+  {
+    id: 1,
+    create_at: "2021-09-01",
+    event: "Pago ingresado",
+    payment_id: 345678,
+    payment_amount: 100000000,
+    user: "Miguel Martinez"
+  },
+  {
+    id: 2,
+    create_at: "2021-09-01",
+    event: "Conciliacion",
+    payment_id: 345678,
+    payment_amount: 100000000,
+    user: "Miguel Martinez"
+  },
+  {
+    id: 3,
+    create_at: "2021-09-01",
+    event: "Aplicacion de pago",
+    payment_id: 345678,
+    payment_amount: 100000000,
+    user: "Miguel Martinez"
+  },
+  {
+    id: 4,
+    create_at: "2021-09-01",
+    event: "Circularizacion",
+    payment_id: 345678,
+    payment_amount: 1000000,
+    user: "Miguel Martinez"
+  },
+  {
+    id: 5,
+    create_at: "2021-09-01",
+    event: "Envio estado de cuenta",
+    payment_id: 345678,
+    payment_amount: 2340000000,
+    user: "Miguel Martinez"
+  }
+];

--- a/src/modules/clients/containers/history-tab/history-tab.tsx
+++ b/src/modules/clients/containers/history-tab/history-tab.tsx
@@ -64,7 +64,7 @@ const mockData = [
   },
   {
     id: 2,
-    create_at: "2021-09-01",
+    create_at: "2021-10-01",
     event: "Conciliacion",
     payment_id: 345678,
     payment_amount: 100000000,
@@ -72,7 +72,7 @@ const mockData = [
   },
   {
     id: 3,
-    create_at: "2021-09-01",
+    create_at: "2021-11-01",
     event: "Aplicacion de pago",
     payment_id: 345678,
     payment_amount: 100000000,
@@ -80,7 +80,7 @@ const mockData = [
   },
   {
     id: 4,
-    create_at: "2021-09-01",
+    create_at: "2021-12-01",
     event: "Circularizacion",
     payment_id: 345678,
     payment_amount: 1000000,
@@ -88,7 +88,7 @@ const mockData = [
   },
   {
     id: 5,
-    create_at: "2021-09-01",
+    create_at: "2021-13-01",
     event: "Envio estado de cuenta",
     payment_id: 345678,
     payment_amount: 2340000000,

--- a/src/modules/clients/containers/history-tab/index.ts
+++ b/src/modules/clients/containers/history-tab/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./history-tab";


### PR DESCRIPTION
Va el tab de historial dentro del detalle de un cliente, además del modal de confirmacion para anular una aplicación, este modal puede reutilizarse donde sea, recibe titulo, contenido, accion a realizar al darle confirmar y al cancelar...
![image](https://github.com/user-attachments/assets/a444f64a-fe45-40b4-aa96-6242f20b06f3)
