### PR TITLE
Refactor client details tab key in ClientDetails component

### DIFF
--- a/src/modules/clients/containers/client-details/client-details.tsx
+++ b/src/modules/clients/containers/client-details/client-details.tsx
@@ -86,7 +86,7 @@ export const ClientDetails: FC<ClientDetailsProps> = () => {
       children: <ContactsTab />
     },
     {
-      key: "6",
+      key: "7",
       label: "Historial",
       children: <HistoryTab />
     }


### PR DESCRIPTION
Severo bug re tonto que menos mal no han visto, se abria el contenido de ambos tabs por tener el mismo id.