### PR TITLE
fix: :bug: approvedAndRejectInvoiceDetailCorrectlyShowingLabelAndOptions

### DIFF
--- a/src/components/molecules/modals/MoldalNoveltyDetail/MoldalNoveltyDetail.tsx
+++ b/src/components/molecules/modals/MoldalNoveltyDetail/MoldalNoveltyDetail.tsx
@@ -25,7 +25,6 @@ const MoldalNoveltyDetail: FC<MoldalNoveltyDetailProps> = ({ onClose, noveltyId 
 
   const [messageShow, contextHolder] = message.useMessage();
   useEffect(() => {
-    
     if (data && data.length > 0) {
       setIncidentData(data[0]);
     }
@@ -81,7 +80,7 @@ const MoldalNoveltyDetail: FC<MoldalNoveltyDetailProps> = ({ onClose, noveltyId 
 
         <div className="header">
           <Title level={4}>{incidentData.incident_name}</Title>
-          {incidentData.is_rejected !== 1 && incidentData.is_rejected !== 0 && (
+          {incidentData.status_name === "pendiente" && (
             <div className="header-buttons">
               <Button onClick={() => handleOpenResolveModal(false)}>
                 <X />
@@ -101,12 +100,7 @@ const MoldalNoveltyDetail: FC<MoldalNoveltyDetailProps> = ({ onClose, noveltyId 
         cliente={incidentData.client}
         aprobadores={[{ nombre: incidentData.approvers_users, estado: "pendiente" }]}
       />
-      <InfoInvoice
-        FacturaID={incidentData.id_erp || ""}
-        invoice_amount_difference={incidentData.invoice_amount_difference || 0}
-        invoice_cashport_value={incidentData.invoice_cashport_value}
-        invoice_client_value={incidentData.invoice_client_value}
-      />
+      <InfoInvoice incidentData={incidentData} />
       <EvidenceSection
         evidenceComments={incidentData.evidence_comments}
         evidenceFiles={incidentData.evidence_files}

--- a/src/components/molecules/modals/MoldalNoveltyDetail/components/infoInvoice/InfoInvoice.tsx
+++ b/src/components/molecules/modals/MoldalNoveltyDetail/components/infoInvoice/InfoInvoice.tsx
@@ -1,46 +1,67 @@
 import React from "react";
 import { NewspaperClipping, Coins } from "phosphor-react";
-import { Typography } from 'antd';
-import "./infoinvoice.scss";
+import { Typography } from "antd";
+
+import { useAppStore } from "@/lib/store/store";
+import { formatMoney } from "@/utils/utils";
+import { useModalDetail } from "@/context/ModalContext";
+import { IIncidentDetail } from "@/hooks/useNoveltyDetail";
+
 import { IconLabel } from "@/components/atoms/IconLabel/IconLabel";
 
+import "./infoinvoice.scss";
 const { Text } = Typography;
 
 interface InfoInvoiceProps {
-  FacturaID: string;
-  invoice_amount_difference?: number;
-  invoice_cashport_value?: number;
-  invoice_client_value?: number;
+  incidentData: IIncidentDetail;
 }
 
-export const InfoInvoice: React.FC<InfoInvoiceProps> = ({
-  FacturaID,
-  invoice_amount_difference,
-  invoice_cashport_value,
-  invoice_client_value
-}) => {
-  const formatCurrency = (value?: number) => {
-    return value?.toLocaleString('es-CO', { style: 'currency', currency: 'COP' });
+export const InfoInvoice: React.FC<InfoInvoiceProps> = ({ incidentData }) => {
+  const {
+    invoice_cashport_value,
+    invoice_amount_difference,
+    invoice_client_value,
+    id_erp: FacturaID,
+    client_id,
+    invoice_id
+  } = incidentData;
+
+  const { ID: projectId } = useAppStore((state) => state.selectedProject);
+
+  const { openModal } = useModalDetail();
+
+  const handleOpenInvoiceDetail = () => {
+    openModal("invoice", {
+      showId: FacturaID,
+      invoiceId: invoice_id,
+      projectId,
+      clientId: client_id,
+      hiddenActions: true
+    });
   };
 
   return (
     <div className="info-invoices">
       <IconLabel icon={<NewspaperClipping size={20} />} text="Factura" />
-      <Text className="invoice-id">{FacturaID}</Text>
-      
+      <Text className="invoice-id" onClick={handleOpenInvoiceDetail}>
+        {FacturaID}
+      </Text>
+
       <IconLabel icon={<Coins size={20} />} text="Valores" />
       <div className="values-container">
         <div className="value-row">
           <Text>Cashport</Text>
-          <Text strong>{formatCurrency(invoice_cashport_value)}</Text>
+          <Text strong>{formatMoney(invoice_cashport_value)}</Text>
         </div>
         <div className="value-row">
           <Text>Cliente</Text>
-          <Text strong>{formatCurrency(invoice_client_value)}</Text>
+          <Text strong>{formatMoney(invoice_client_value)}</Text>
         </div>
         <div className="value-row difference">
           <Text>Novedad</Text>
-          <Text type="danger" strong>{formatCurrency(invoice_amount_difference)}</Text>
+          <Text type="danger" strong>
+            {formatMoney(invoice_amount_difference || 0)}
+          </Text>
         </div>
       </div>
     </div>

--- a/src/components/molecules/modals/MoldalNoveltyDetail/components/infoInvoice/infoinvoice.scss
+++ b/src/components/molecules/modals/MoldalNoveltyDetail/components/infoInvoice/infoinvoice.scss
@@ -5,33 +5,34 @@
     align-items: start;
     border-top: 1px solid #e8e8e8;
     padding: 16px;
-  
+
     .invoice-id {
-      color: #1890ff;
-      font-weight: bold;
+        color: #1890ff;
+        font-weight: bold;
+        cursor: pointer;
     }
-  
+
     .values-container {
-      display: grid;
-      grid-template-columns: 1fr 2fr;
-      gap: 4px;
-  
-      .value-row {
-        display: contents;
-  
-        span:first-child {
-          color: #8c8c8c;
+        display: grid;
+        grid-template-columns: 1fr 2fr;
+        gap: 4px;
+
+        .value-row {
+            display: contents;
+
+            span:first-child {
+                color: #8c8c8c;
+            }
+
+            span:last-child {
+                text-align: left;
+            }
         }
-  
-        span:last-child {
-          text-align:  left;
+
+        .difference {
+            span:last-child {
+                color: #ff4d4f;
+            }
         }
-      }
-  
-      .difference {
-        span:last-child {
-          color: #ff4d4f;
-        }
-      }
     }
-  }
+}

--- a/src/hooks/useNoveltyDetail.tsx
+++ b/src/hooks/useNoveltyDetail.tsx
@@ -27,7 +27,10 @@ export interface IIncidentDetail {
   invoice_client_value: number;
   approvers_users: string;
   events: IEvent[];
-  is_rejected: number;
+  is_rejected: number | null;
+  client_amount: number;
+  status: number;
+  status_name: string;
 }
 
 interface IIncidentDetailResponse {

--- a/src/modules/clients/containers/invoice-detail-modal/invoice-detail-modal.tsx
+++ b/src/modules/clients/containers/invoice-detail-modal/invoice-detail-modal.tsx
@@ -212,9 +212,9 @@ const InvoiceDetailModal: FC<InvoiceDetailModalProps> = ({
                                     }`}
                                   >
                                     {item.is_rejected === 1
-                                      ? "Rechazada"
+                                      ? "Aprobada"
                                       : item.is_rejected === 0
-                                        ? "Aprobada"
+                                        ? "Rechazada"
                                         : "Pendiente"}
                                   </span>
                                 )}


### PR DESCRIPTION
Also added Navigation back to invoice modal detail
Ahora el tag de rechazado o Aprobado sale acorde al estado
![image](https://github.com/user-attachments/assets/a57804a1-2ec3-40f7-9bb8-dcd994d87c76)

Y el numero de factrua sirve como vinculo para abrir el detlle de la factura de nuevo.
![image](https://github.com/user-attachments/assets/584afc42-aee5-469e-b677-9ab29eb4ddeb)

Si no está pendiente de aprobar o rechazar entonces no salen los botones
![image](https://github.com/user-attachments/assets/11ea95a7-9bea-4683-b7eb-e87a6da66a4e)
![image](https://github.com/user-attachments/assets/ed122d6a-6526-4ac3-8ec6-e487af55463b)
