### PR TITLE
fix: Correct tag label colors in invoice detail modal

### DIFF
--- a/src/modules/clients/containers/invoice-detail-modal/invoice-detail-modal.tsx
+++ b/src/modules/clients/containers/invoice-detail-modal/invoice-detail-modal.tsx
@@ -205,9 +205,9 @@ const InvoiceDetailModal: FC<InvoiceDetailModalProps> = ({
                                   <span
                                     className={`${styles.tagLabel} ${
                                       item.is_rejected === 1
-                                        ? styles.tagLabelRose
+                                        ? styles.tagLabelGreen
                                         : item.is_rejected === 0
-                                          ? styles.tagLabelGreen
+                                          ? styles.tagLabelRose
                                           : styles.tagLabelRed
                                     }`}
                                   >


### PR DESCRIPTION
This pull request includes a minor update to the `InvoiceDetailModal` component to correct the conditional styling logic.

Styling logic correction:

* [`src/modules/clients/containers/invoice-detail-modal/invoice-detail-modal.tsx`](diffhunk://#diff-3d3af98a6e52d0db9d3cd91b836f0686ce17e559afd22ce5852d4138ee112248L208-R210): Fixed the conditional logic for applying CSS classes based on the `is_rejected` property of an item.