### PR TITLE
Fix/connect template info communications form

### DIFF
--- a/src/components/molecules/tabs/Projects/CommunicationProjectForm/CommunicationProjectForm.tsx
+++ b/src/components/molecules/tabs/Projects/CommunicationProjectForm/CommunicationProjectForm.tsx
@@ -170,6 +170,7 @@ export const CommunicationProjectForm = ({
         setAssignedGroups(res.client_group_id.map((group) => group.id));
 
         const { repeat, end_date, start_date } = res.JSON_frecuency;
+        if (Object.keys(res.JSON_frecuency).length === 0) return;
         setSelectedPeriodicity({
           init_date: dayjs(new Date(start_date)).add(1, "day"),
           frequency_number: repeat.interval,
@@ -223,7 +224,6 @@ export const CommunicationProjectForm = ({
 
   const handleCreateCommunication = async (data: any) => {
     setLoadingRequest(true);
-    console.log("data", data);
     if (
       zones.length === 0 ||
       selectedBusinessRules?.channels.length === 0 ||

--- a/src/components/molecules/tabs/Projects/CommunicationProjectForm/CommunicationProjectForm.tsx
+++ b/src/components/molecules/tabs/Projects/CommunicationProjectForm/CommunicationProjectForm.tsx
@@ -738,9 +738,8 @@ const dataToDataForm = (data: ICommunicationDetail | undefined): ICommunicationF
       send_to: send_to,
       copy_to: [],
       tags: [{ value: "1", label: "Quemado" }],
-      message: "quemado",
-      title: "quemado",
-      subject: "quemado",
+      message: data.message,
+      subject: data.subject,
       files: []
     }
   };

--- a/src/types/communications/ICommunications.ts
+++ b/src/types/communications/ICommunications.ts
@@ -19,7 +19,6 @@ interface ITemplateForm {
   copy_to: ISelectStringType[] | undefined;
   tags: ISelectStringType[];
   message: string;
-  title?: string;
   subject: string;
   files: ISelectStringType[];
 }


### PR DESCRIPTION
This pull request includes several changes to the `CommunicationProjectForm` component and related types to improve functionality and remove redundant code. The most important changes include adding a check for empty frequency objects, removing console logs, and updating the data transformation logic.

Improvements to functionality:

* [`src/components/molecules/tabs/Projects/CommunicationProjectForm/CommunicationProjectForm.tsx`](diffhunk://#diff-6d675c7980129762b4b98647061098f449bb3ee8b5599e9743675eb8f1390c91R173): Added a check to return early if `JSON_frecuency` is empty in the `setAssignedGroups` function.

Code cleanup:

* [`src/components/molecules/tabs/Projects/CommunicationProjectForm/CommunicationProjectForm.tsx`](diffhunk://#diff-6d675c7980129762b4b98647061098f449bb3ee8b5599e9743675eb8f1390c91L226): Removed a `console.log` statement from the `handleCreateCommunication` function.

Data transformation updates:

* [`src/components/molecules/tabs/Projects/CommunicationProjectForm/CommunicationProjectForm.tsx`](diffhunk://#diff-6d675c7980129762b4b98647061098f449bb3ee8b5599e9743675eb8f1390c91L741-R742): Updated the `dataToDataForm` function to use `data.message` and `data.subject` instead of hardcoded strings.

Type definition updates:

* [`src/types/communications/ICommunications.ts`](diffhunk://#diff-b29000b91ff54d73643d5f1de58c1f5ffff9ff5630065dad825ed7a5a4d1e8e7L22): Removed the optional `title` property from the `ITemplateForm` interface.