### PR TITLE
fix: :bug: update validation rules to make reference field optional

### DIFF
--- a/src/modules/clients/components/payments-tab/modal-identify-payment-action/modal-identify-payment-action.tsx
+++ b/src/modules/clients/components/payments-tab/modal-identify-payment-action/modal-identify-payment-action.tsx
@@ -231,7 +231,7 @@ const ModalIdentifyPayment: FC<ModalIdentifyPaymentProps> = ({ isOpen, onClose }
             />
 
             <InputForm
-              validationRules={{ required: true }}
+              validationRules={{ required: false }}
               titleInput="Referencia"
               control={control}
               nameInput="reference"


### PR DESCRIPTION
This pull request includes a small change to the `src/modules/clients/components/payments-tab/modal-identify-payment-action/modal-identify-payment-action.tsx` file. The change modifies the validation rules for the `InputForm` component, making the `Referencia` field optional instead of required.

* [`src/modules/clients/components/payments-tab/modal-identify-payment-action/modal-identify-payment-action.tsx`](diffhunk://#diff-abee7ab66301eb4ce89a53dea0d9e09c83d0b771bea744d722762d541b4309e3L234-R234): Changed `validationRules` for `InputForm` from `{ required: true }` to `{ required: false }`.