### PR TITLE
Feat/refactor history tab

### DIFF
--- a/src/hooks/useClientHistory.ts
+++ b/src/hooks/useClientHistory.ts
@@ -1,0 +1,32 @@
+import useSWR from "swr";
+import { fetcher } from "@/utils/api/api";
+
+import { useAppStore } from "@/lib/store/store";
+
+import { GenericResponse } from "@/types/global/IGlobal";
+import { IHistoryRow } from "@/types/clientHistory/IClientHistory";
+
+type useBankRulesProps = {
+  clientId: number;
+};
+
+interface IDetailResponse {
+  error: string;
+  message: string;
+  data: IHistoryRow[];
+}
+
+export const useClientHistory = ({ clientId }: useBankRulesProps) => {
+  const { ID } = useAppStore((state) => state.selectedProject);
+
+  const pathKey = `/history/get-history?project_id=${ID}&client_id=${clientId}`;
+
+  const { data, error, mutate } = useSWR<GenericResponse<IDetailResponse>>(pathKey, fetcher);
+
+  return {
+    data: data?.data.data,
+    isLoading: !error && !data,
+    error,
+    mutate
+  };
+};

--- a/src/modules/clients/components/history-tab-modal-generate-action/History-tab-modal-generate-action.tsx
+++ b/src/modules/clients/components/history-tab-modal-generate-action/History-tab-modal-generate-action.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { Flex, Modal } from "antd";
+import { X } from "@phosphor-icons/react";
+
+import { ButtonGenerateAction } from "@/components/atoms/ButtonGenerateAction/ButtonGenerateAction";
+
+import "./history-tab-modal-generate-action.scss";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  // eslint-disable-next-line no-unused-vars
+  setSelectOpen: (args: { selected: number }) => void;
+}
+
+const ModalActionsHistoryTab = ({ isOpen, onClose, setSelectOpen }: Props) => {
+  const handleOpenModal = (type: number) => {
+    setSelectOpen({
+      selected: type
+    });
+  };
+  return (
+    <Modal
+      className="modalActionsHistoryTab"
+      width={686}
+      open={isOpen}
+      title={null}
+      footer={null}
+      onCancel={onClose}
+    >
+      <p className="modalActionsHistoryTab__description">Selecciona la acción que vas a realizar</p>
+      <Flex vertical gap="0.75rem">
+        <ButtonGenerateAction
+          onClick={() => {
+            handleOpenModal(2);
+          }}
+          icon={<X size={16} />}
+          title="Anular pago"
+        />
+      </Flex>
+    </Modal>
+  );
+};
+
+export default ModalActionsHistoryTab;

--- a/src/modules/clients/components/history-tab-modal-generate-action/history-tab-modal-generate-action.scss
+++ b/src/modules/clients/components/history-tab-modal-generate-action/history-tab-modal-generate-action.scss
@@ -1,0 +1,27 @@
+@import "@/styles/variables.scss";
+
+.modalActionsHistoryTab {
+    max-height: 90%;
+    .ant-modal-content {
+        padding: 2rem !important;
+
+        .ant-modal-close {
+            margin: 1.2rem;
+        }
+    }
+
+    &__description {
+        font-size: 1rem;
+        font-weight: 300;
+    }
+
+    .ant-modal-body {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+    }
+
+    .ant-collapse-header {
+        border-radius: 8px !important;
+    }
+}

--- a/src/modules/clients/components/history-tab-modal-generate-action/index.ts
+++ b/src/modules/clients/components/history-tab-modal-generate-action/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./History-tab-modal-generate-action";

--- a/src/modules/clients/components/history-tab-table/history-tab-table.tsx
+++ b/src/modules/clients/components/history-tab-table/history-tab-table.tsx
@@ -1,17 +1,20 @@
 import { useState } from "react";
-import { Button, Flex, Table, TableProps, Tooltip, Typography } from "antd";
-import { DotsThreeVertical, DownloadSimple, Paperclip, Trash, Triangle } from "phosphor-react";
+import { Button, Flex, Table, TableProps, Typography } from "antd";
+import { Eye, Triangle } from "phosphor-react";
+
+import { formatDate } from "@/utils/utils";
 
 import useScreenHeight from "@/components/hooks/useScreenHeight";
-import { IHistoryRecord } from "../../containers/history-tab/history-tab";
 import { ModalConfirmAction } from "@/components/molecules/modals/ModalConfirmAction/ModalConfirmAction";
+
+import { IHistoryRow } from "@/types/clientHistory/IClientHistory";
 
 import "./history-tab-table.scss";
 
 const { Text } = Typography;
 
 interface PropsHistoryTable {
-  dataAllRecords: IHistoryRecord[];
+  dataAllRecords?: IHistoryRow[];
 }
 
 const HistoryTable = ({ dataAllRecords: data }: PropsHistoryTable) => {
@@ -32,31 +35,13 @@ const HistoryTable = ({ dataAllRecords: data }: PropsHistoryTable) => {
     setIsConfirmCancelModalOpen({ isOpen: false, id: 0 });
   };
 
-  const tootlTipOptions = [
-    {
-      title: "PDF",
-      icon: <DownloadSimple size={"1.2rem"} />,
-      onClick: () => console.info("PDF")
-    },
-    {
-      title: "Excel",
-      icon: <DownloadSimple size={"1.2rem"} />,
-      onClick: () => console.info("Excel")
-    },
-    {
-      title: "Anular aplicación",
-      icon: <Trash size={"1.2rem"} />,
-      onClick: (recordId: number) => setIsConfirmCancelModalOpen({ isOpen: true, id: recordId })
-    }
-  ];
-
-  const columns: TableProps<IHistoryRecord>["columns"] = [
+  const columns: TableProps<IHistoryRow>["columns"] = [
     {
       title: "Fecha",
-      dataIndex: "create_at",
-      key: "create_at",
-      render: (create_at) => <Text className="cell">{create_at}</Text>,
-      sorter: (a, b) => a.create_at.localeCompare(b.create_at),
+      dataIndex: "created_at",
+      key: "created_at",
+      render: (created_at) => <Text className="cell">{formatDate(created_at)}</Text>,
+      sorter: (a, b) => a.created_at.localeCompare(b.created_at),
       showSorterTooltip: false,
       width: 120
     },
@@ -70,53 +55,32 @@ const HistoryTable = ({ dataAllRecords: data }: PropsHistoryTable) => {
     },
     {
       title: "Descripción",
-      key: "payment_amount",
-      dataIndex: "payment_amount",
-      render: (payment_amount, row) => (
-        <span className="cell">
-          Pago {<span className="highlightText">#{row.payment_id}</span>} por {payment_amount}
-        </span>
-      ),
-      sorter: (a, b) => a.payment_amount - b.payment_amount,
+      key: "description",
+      dataIndex: "description",
+      render: (description) => <span className="cell">{description}</span>,
+      sorter: (a, b) => a.description.localeCompare(b.description),
       showSorterTooltip: false
     },
     {
       title: "Usuario",
-      key: "user",
-      dataIndex: "user",
+      key: "user_name",
+      dataIndex: "user_name",
       render: (text) => <Text className="cell">{text}</Text>,
-      sorter: (a, b) => a.user.localeCompare(b.user),
+      sorter: (a, b) => a.user_name.localeCompare(b.user_name),
       showSorterTooltip: false
     },
     {
       title: "",
       render: (_, record) => (
         <Flex gap="0.5rem">
-          <Button className="eyeButton" icon={<Paperclip size={"1.2rem"} />} />
-          <Tooltip
-            overlayClassName="tooltipHistoryOptions"
-            title={
-              <Flex vertical gap={"0.5rem"}>
-                {tootlTipOptions.map((option) => (
-                  <Button
-                    key={option.title}
-                    className="tooltipButton"
-                    icon={option.icon}
-                    onClick={() => option.onClick(record.id)}
-                  >
-                    <p>{option.title}</p>
-                  </Button>
-                ))}
-              </Flex>
-            }
-            color={"white"}
-            key={record.id}
-          >
-            <Button className="eyeButton" icon={<DotsThreeVertical size={"1.2rem"} />} />
-          </Tooltip>
+          <Button
+            className="eyeButton"
+            onClick={() => setIsConfirmCancelModalOpen({ isOpen: true, id: record.id })}
+            icon={<Eye size={"1.2rem"} />}
+          />
         </Flex>
       ),
-      width: 100
+      width: 65
     }
   ];
 

--- a/src/modules/clients/components/history-tab-table/history-tab-table.tsx
+++ b/src/modules/clients/components/history-tab-table/history-tab-table.tsx
@@ -5,7 +5,6 @@ import { Eye, Triangle } from "phosphor-react";
 import { formatDate } from "@/utils/utils";
 
 import useScreenHeight from "@/components/hooks/useScreenHeight";
-import { ModalConfirmAction } from "@/components/molecules/modals/ModalConfirmAction/ModalConfirmAction";
 
 import { IHistoryRow } from "@/types/clientHistory/IClientHistory";
 
@@ -20,31 +19,18 @@ interface PropsHistoryTable {
 
 const HistoryTable = ({ dataAllRecords: data, setSelectedRows }: PropsHistoryTable) => {
   const [page, setPage] = useState(1);
-  const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
-  const [isConfirmCancelModalOpen, setIsConfirmCancelModalOpen] = useState({
-    isOpen: false,
-    id: 0
-  });
-
   const height = useScreenHeight();
 
   const onChangePage = (pagePagination: number) => {
     setPage(pagePagination);
   };
 
-  const handleCancelApplication = () => {
-    console.info("Anular aplicación con id", isConfirmCancelModalOpen.id);
-    setIsConfirmCancelModalOpen({ isOpen: false, id: 0 });
-  };
-
-  const onSelectChange = (newSelectedRowKeys: React.Key[], newSelectedRow: any) => {
-    setSelectedRowKeys(newSelectedRowKeys);
+  const onSelectChange = (_newSelectedRowKeys: React.Key[], newSelectedRow: any) => {
     setSelectedRows(newSelectedRow);
   };
 
   const rowSelection = {
     columnWidth: 40,
-    selectedRowKeys,
     onChange: onSelectChange
   };
 
@@ -84,11 +70,11 @@ const HistoryTable = ({ dataAllRecords: data, setSelectedRows }: PropsHistoryTab
     },
     {
       title: "",
-      render: (_, record) => (
+      render: () => (
         <Flex gap="0.5rem">
           <Button
             className="eyeButton"
-            onClick={() => setIsConfirmCancelModalOpen({ isOpen: true, id: record.id })}
+            onClick={() => console.info("Ver detalle")}
             icon={<Eye size={"1.2rem"} />}
           />
         </Flex>
@@ -122,19 +108,6 @@ const HistoryTable = ({ dataAllRecords: data, setSelectedRows }: PropsHistoryTab
             return originalElement;
           }
         }}
-      />
-      <ModalConfirmAction
-        isOpen={isConfirmCancelModalOpen.isOpen}
-        onClose={() =>
-          setIsConfirmCancelModalOpen({
-            isOpen: false,
-            id: 0
-          })
-        }
-        title="¿Estás seguro que deseas anular esta apliación?"
-        content="Esta acción es definitiva"
-        onOk={handleCancelApplication}
-        okText="Anular aplicación"
       />
     </>
   );

--- a/src/modules/clients/components/history-tab-table/history-tab-table.tsx
+++ b/src/modules/clients/components/history-tab-table/history-tab-table.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 import { Button, Flex, Table, TableProps, Typography } from "antd";
 import { Eye, Triangle } from "phosphor-react";
 
@@ -15,10 +15,12 @@ const { Text } = Typography;
 
 interface PropsHistoryTable {
   dataAllRecords?: IHistoryRow[];
+  setSelectedRows: Dispatch<SetStateAction<IHistoryRow[] | undefined>>;
 }
 
-const HistoryTable = ({ dataAllRecords: data }: PropsHistoryTable) => {
+const HistoryTable = ({ dataAllRecords: data, setSelectedRows }: PropsHistoryTable) => {
   const [page, setPage] = useState(1);
+  const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
   const [isConfirmCancelModalOpen, setIsConfirmCancelModalOpen] = useState({
     isOpen: false,
     id: 0
@@ -33,6 +35,17 @@ const HistoryTable = ({ dataAllRecords: data }: PropsHistoryTable) => {
   const handleCancelApplication = () => {
     console.info("Anular aplicación con id", isConfirmCancelModalOpen.id);
     setIsConfirmCancelModalOpen({ isOpen: false, id: 0 });
+  };
+
+  const onSelectChange = (newSelectedRowKeys: React.Key[], newSelectedRow: any) => {
+    setSelectedRowKeys(newSelectedRowKeys);
+    setSelectedRows(newSelectedRow);
+  };
+
+  const rowSelection = {
+    columnWidth: 40,
+    selectedRowKeys,
+    onChange: onSelectChange
   };
 
   const columns: TableProps<IHistoryRow>["columns"] = [
@@ -90,6 +103,7 @@ const HistoryTable = ({ dataAllRecords: data }: PropsHistoryTable) => {
         className="historyTable"
         columns={columns}
         dataSource={data?.map((data) => ({ ...data, key: data.id }))}
+        rowSelection={rowSelection}
         virtual
         scroll={{ y: height - 400, x: 100 }}
         pagination={{

--- a/src/modules/clients/containers/history-tab/history-tab.module.scss
+++ b/src/modules/clients/containers/history-tab/history-tab.module.scss
@@ -1,0 +1,14 @@
+@import "@styles/variables.scss";
+
+.historyTab {
+    .button__actions {
+        padding: 0.75rem 1rem;
+        background-color: $background;
+        border: solid 1px transparent;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        height: 3rem;
+        font-size: 1rem;
+    }
+}

--- a/src/modules/clients/containers/history-tab/history-tab.scss
+++ b/src/modules/clients/containers/history-tab/history-tab.scss
@@ -1,1 +1,0 @@
-@import "@styles/variables.scss";

--- a/src/modules/clients/containers/history-tab/history-tab.tsx
+++ b/src/modules/clients/containers/history-tab/history-tab.tsx
@@ -1,5 +1,9 @@
 import { useState } from "react";
 import { Flex, Spin } from "antd";
+import { useParams } from "next/navigation";
+
+import { extractSingleParam } from "@/utils/utils";
+import { useClientHistory } from "@/hooks/useClientHistory";
 
 import UiSearchInput from "@/components/ui/search-input";
 import { DotsDropdown } from "@/components/atoms/DotsDropdown/DotsDropdown";
@@ -9,8 +13,12 @@ import HistoryTable from "../../components/history-tab-table";
 import "./history-tab.scss";
 
 const HistoryTab = () => {
+  const params = useParams();
+  const clientIdParam = extractSingleParam(params.clientId);
   const [search, setSearch] = useState("");
   const isLoading = false;
+
+  const { data } = useClientHistory({ clientId: Number(clientIdParam) });
 
   return (
     <>
@@ -35,7 +43,7 @@ const HistoryTab = () => {
               <DotsDropdown />
             </Flex>
           </Flex>
-          <HistoryTable dataAllRecords={mockData} />
+          <HistoryTable dataAllRecords={data} />
         </div>
       )}
     </>
@@ -43,55 +51,3 @@ const HistoryTab = () => {
 };
 
 export default HistoryTab;
-
-export interface IHistoryRecord {
-  id: number;
-  create_at: string;
-  event: string;
-  payment_id: number;
-  payment_amount: number;
-  user: string;
-}
-
-const mockData = [
-  {
-    id: 1,
-    create_at: "2021-09-01",
-    event: "Pago ingresado",
-    payment_id: 345678,
-    payment_amount: 100000000,
-    user: "Miguel Martinez"
-  },
-  {
-    id: 2,
-    create_at: "2021-10-01",
-    event: "Conciliacion",
-    payment_id: 345678,
-    payment_amount: 100000000,
-    user: "Miguel Martinez"
-  },
-  {
-    id: 3,
-    create_at: "2021-11-01",
-    event: "Aplicacion de pago",
-    payment_id: 345678,
-    payment_amount: 100000000,
-    user: "Miguel Martinez"
-  },
-  {
-    id: 4,
-    create_at: "2021-12-01",
-    event: "Circularizacion",
-    payment_id: 345678,
-    payment_amount: 1000000,
-    user: "Miguel Martinez"
-  },
-  {
-    id: 5,
-    create_at: "2021-13-01",
-    event: "Envio estado de cuenta",
-    payment_id: 345678,
-    payment_amount: 2340000000,
-    user: "Miguel Martinez"
-  }
-];

--- a/src/modules/clients/containers/history-tab/history-tab.tsx
+++ b/src/modules/clients/containers/history-tab/history-tab.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Button, Flex, Spin } from "antd";
 import { useParams } from "next/navigation";
+import { DotsThree } from "phosphor-react";
 
 import { extractSingleParam } from "@/utils/utils";
 import { useClientHistory } from "@/hooks/useClientHistory";
@@ -8,10 +9,12 @@ import { useClientHistory } from "@/hooks/useClientHistory";
 import UiSearchInput from "@/components/ui/search-input";
 import UiFilterDropdown from "@/components/ui/ui-filter-dropdown";
 import HistoryTable from "../../components/history-tab-table";
+import ModalActionsHistoryTab from "../../components/history-tab-modal-generate-action";
+import { ModalConfirmAction } from "@/components/molecules/modals/ModalConfirmAction/ModalConfirmAction";
+
+import { IHistoryRow } from "@/types/clientHistory/IClientHistory";
 
 import styles from "./history-tab.module.scss";
-import { DotsThree } from "phosphor-react";
-import { IHistoryRow } from "@/types/clientHistory/IClientHistory";
 
 const HistoryTab = () => {
   const params = useParams();
@@ -22,6 +25,12 @@ const HistoryTab = () => {
   const isLoading = false;
 
   const { data } = useClientHistory({ clientId: Number(clientIdParam) });
+
+  const handleCancelApplication = () => {
+    console.log("Anular aplicación");
+    console.log(selectedRows);
+    setOpenModal({ selected: 0 });
+  };
 
   return (
     <>
@@ -47,7 +56,6 @@ const HistoryTab = () => {
                 className={styles.button__actions}
                 size="large"
                 icon={<DotsThree size={"1.5rem"} />}
-                disabled={false}
                 onClick={() => setOpenModal({ selected: 1 })}
               >
                 Generar acción
@@ -55,6 +63,21 @@ const HistoryTab = () => {
             </Flex>
           </Flex>
           <HistoryTable dataAllRecords={data} setSelectedRows={setSelectedRows} />
+
+          <ModalActionsHistoryTab
+            isOpen={openModal.selected === 1}
+            onClose={() => setOpenModal({ selected: 0 })}
+            setSelectOpen={setOpenModal}
+          />
+
+          <ModalConfirmAction
+            isOpen={openModal.selected === 2}
+            onClose={() => setOpenModal({ selected: 0 })}
+            title="¿Estás seguro que deseas anular esta apliación?"
+            content="Esta acción es definitiva"
+            onOk={handleCancelApplication}
+            okText="Anular aplicación"
+          />
         </div>
       )}
     </>

--- a/src/modules/clients/containers/history-tab/history-tab.tsx
+++ b/src/modules/clients/containers/history-tab/history-tab.tsx
@@ -1,21 +1,24 @@
 import { useState } from "react";
-import { Flex, Spin } from "antd";
+import { Button, Flex, Spin } from "antd";
 import { useParams } from "next/navigation";
 
 import { extractSingleParam } from "@/utils/utils";
 import { useClientHistory } from "@/hooks/useClientHistory";
 
 import UiSearchInput from "@/components/ui/search-input";
-import { DotsDropdown } from "@/components/atoms/DotsDropdown/DotsDropdown";
 import UiFilterDropdown from "@/components/ui/ui-filter-dropdown";
 import HistoryTable from "../../components/history-tab-table";
 
-import "./history-tab.scss";
+import styles from "./history-tab.module.scss";
+import { DotsThree } from "phosphor-react";
+import { IHistoryRow } from "@/types/clientHistory/IClientHistory";
 
 const HistoryTab = () => {
   const params = useParams();
   const clientIdParam = extractSingleParam(params.clientId);
+  const [selectedRows, setSelectedRows] = useState<IHistoryRow[] | undefined>(undefined);
   const [search, setSearch] = useState("");
+  const [openModal, setOpenModal] = useState({ selected: 0 });
   const isLoading = false;
 
   const { data } = useClientHistory({ clientId: Number(clientIdParam) });
@@ -27,8 +30,8 @@ const HistoryTab = () => {
           <Spin />
         </Flex>
       ) : (
-        <div className="historyTab">
-          <Flex justify="space-between" className="historyTab__header">
+        <div className={styles.historyTab}>
+          <Flex justify="space-between">
             <Flex gap={"0.5rem"}>
               <UiSearchInput
                 className="search"
@@ -40,10 +43,18 @@ const HistoryTab = () => {
                 }}
               />
               <UiFilterDropdown />
-              <DotsDropdown />
+              <Button
+                className={styles.button__actions}
+                size="large"
+                icon={<DotsThree size={"1.5rem"} />}
+                disabled={false}
+                onClick={() => setOpenModal({ selected: 1 })}
+              >
+                Generar acción
+              </Button>
             </Flex>
           </Flex>
-          <HistoryTable dataAllRecords={data} />
+          <HistoryTable dataAllRecords={data} setSelectedRows={setSelectedRows} />
         </div>
       )}
     </>

--- a/src/types/clientHistory/IClientHistory.ts
+++ b/src/types/clientHistory/IClientHistory.ts
@@ -1,0 +1,12 @@
+export interface IHistoryRow {
+  id: number;
+  event: string;
+  description: string;
+  project_id: number;
+  id_client: number;
+  userId: number;
+  created_at: string;
+  is_deleted: number;
+  url: string;
+  user_name: string;
+}


### PR DESCRIPTION
Va el tab de historial conectado, a la vez que se agregó el seleccionar, el modal de generar accion y el flujo para nular la aplicacion de pago como dice la historia y el figma...
![image](https://github.com/user-attachments/assets/946705c2-b667-49d3-be2d-74df1333b56c)
![image](https://github.com/user-attachments/assets/325510b9-9ea1-48fd-aecc-56aaf10772df)
![image](https://github.com/user-attachments/assets/505d8146-3c61-48c1-932b-c59b433898a1)
