### PR TITLE
fix: :bug: Update invoice detail modal to display payment agreement I…

### DIFF
--- a/src/modules/clients/containers/invoice-detail-modal/invoice-detail-modal.tsx
+++ b/src/modules/clients/containers/invoice-detail-modal/invoice-detail-modal.tsx
@@ -366,7 +366,7 @@ const InvoiceDetailModal: FC<InvoiceDetailModalProps> = ({
                                       }}
                                     >
                                       {" "}
-                                      {`${item.id}`}
+                                      {`${item.payment_agreement_id}`}
                                     </div>
                                   </div>
                                 </div>

--- a/src/types/clients/invoice-detail.ts
+++ b/src/types/clients/invoice-detail.ts
@@ -33,6 +33,7 @@ export interface IData {
   is_deleted: number;
   is_legalized: number;
   is_rejected: number | null;
+  payment_agreement_id: number;
   previous_status: string | null;
   previous_status_id: number | null;
   project_id: number;


### PR DESCRIPTION
This pull request includes changes to the `InvoiceDetailModal` component and the `IData` interface to incorporate the `payment_agreement_id` field. The most important changes are as follows:

### Changes to `InvoiceDetailModal` component:

* Updated the `InvoiceDetailModal` component to display `payment_agreement_id` instead of `item.id`. (`src/modules/clients/containers/invoice-detail-modal/invoice-detail-modal.tsx`)

### Changes to `IData` interface:

* Added the `payment_agreement_id` field to the `IData` interface to support the new field in the `InvoiceDetailModal` component. (`src/types/clients/invoice-detail.ts`)…D instead of item ID