### PR TITLE
IClientsGroup interfaces changed by new typing

### DIFF
--- a/src/components/molecules/tables/ClientsGroupsTable/ClientsGroupsTable.tsx
+++ b/src/components/molecules/tables/ClientsGroupsTable/ClientsGroupsTable.tsx
@@ -134,13 +134,13 @@ export const ClientsGroupsTable = ({ setShowGroupDetails }: PropsClientsGroupsTa
       title: "Clientes",
       dataIndex: "clients_count",
       key: "clients_count",
-      sorter: (a, b) => (a.clients?.length || 0) - (b.clients?.length || 0),
-      render: (clients, row) => <Text>{row?.clients?.length}</Text>
+      sorter: (a, b) => (a.clients_count || 0) - (b.clients_count || 0),
+      render: (clients, row) => <Text>{row?.clients_count}</Text>
     },
     {
       title: "Suscritos",
-      key: "subcribers",
-      dataIndex: "subcribers",
+      key: "subscribers",
+      dataIndex: "subscribers",
       sorter: (a, b) => (a.subscribers || 0) - (b.subscribers || 0),
       render: (text) => <Text>{text ? text : 0}</Text>
     },

--- a/src/types/clientsGroups/IClientsGroups.ts
+++ b/src/types/clientsGroups/IClientsGroups.ts
@@ -22,6 +22,7 @@ export interface IClient {
 export interface IClientsGroup {
   id: number;
   group_name: string;
+  clients_count: number;
   clients: IClient[];
   active: number;
   project_id: number;


### PR DESCRIPTION
This pull request includes changes to the `ClientsGroupsTable` component and the `IClientsGroup` interface to improve data handling and correct a typo.

Improvements to data handling:

* [`src/components/molecules/tables/ClientsGroupsTable/ClientsGroupsTable.tsx`](diffhunk://#diff-7e0eb77e177005c08fcea4aa55dcbdd251be5d516ad88c8e809643a9ee103a2dL137-R143): Modified the `clients_count` column to use the `clients_count` field directly instead of calculating it from the `clients` array.
* [`src/types/clientsGroups/IClientsGroups.ts`](diffhunk://#diff-83f4ac12409a8fbf51d5dded16c628147c3d006e1bfc1ca8a1e291f7ed4c9624R25): Added a new `clients_count` field to the `IClientsGroup` interface.

Typo correction:

* [`src/components/molecules/tables/ClientsGroupsTable/ClientsGroupsTable.tsx`](diffhunk://#diff-7e0eb77e177005c08fcea4aa55dcbdd251be5d516ad88c8e809643a9ee103a2dL137-R143): Corrected a typo in the `subscribers` column key and data index.