### PR TITLE
Fix/clients table sort and send email modal on close conciliation

### DIFF
--- a/src/components/molecules/modals/ModalSendEmail/ModalSendEmail.tsx
+++ b/src/components/molecules/modals/ModalSendEmail/ModalSendEmail.tsx
@@ -39,8 +39,9 @@ interface Props {
   onClose: () => void;
   event: string;
   onFinalOk?: () => void;
+  customOnReject?: () => void;
 }
-export const ModalSendEmail = ({ isOpen, onClose, onFinalOk }: Props) => {
+export const ModalSendEmail = ({ isOpen, onClose, onFinalOk, customOnReject }: Props) => {
   const { ID: projectId } = useAppStore((state) => state.selectedProject);
   const params = useParams();
   const clientId = parseInt(extractSingleParam(params.clientId) || "0");
@@ -99,6 +100,11 @@ export const ModalSendEmail = ({ isOpen, onClose, onFinalOk }: Props) => {
     fetchFormInfo();
   }, [projectId, clientId, isOpen]);
 
+  const handleRejectSendingEmail = () => {
+    if (customOnReject) return customOnReject(), onClose();
+    onClose();
+  };
+
   const handleAcceptSendingEmail = () => {
     // send email request to verify template
     //change view to template
@@ -138,7 +144,7 @@ export const ModalSendEmail = ({ isOpen, onClose, onFinalOk }: Props) => {
 
           <p className="modalSendEmail__description">{sendEmailConstants.description}</p>
           <div className="modalSendEmail__footer">
-            <SecondaryButton onClick={() => onClose()}>
+            <SecondaryButton onClick={handleRejectSendingEmail}>
               {sendEmailConstants.cancelText}
             </SecondaryButton>
 

--- a/src/components/molecules/modals/RegisterNewsConcilation/RegisterNewsConcilation.tsx
+++ b/src/components/molecules/modals/RegisterNewsConcilation/RegisterNewsConcilation.tsx
@@ -154,6 +154,9 @@ const RegisterNewsConcilation = ({
             event: "massConciliation",
             onFinalOk: () => {
               router.push(`/clientes/detail/${clientId}/project/${ID}`);
+            },
+            customOnReject: () => {
+              router.push(`/clientes/detail/${clientId}/project/${ID}`);
             }
           });
         }

--- a/src/components/organisms/Customers/ClientsViewTable/ClientsViewTable.tsx
+++ b/src/components/organisms/Customers/ClientsViewTable/ClientsViewTable.tsx
@@ -166,7 +166,11 @@ export const ClientsViewTable = () => {
       title: "PNA",
       key: "unapplied_payments_ammount",
       dataIndex: "unapplied_payments_ammount",
-      render: (text) => <p className="fontMonoSpace">{formatMoney(text, { hideDecimals: true })}</p>
+      render: (text) => (
+        <p className="fontMonoSpace">{formatMoney(text, { hideDecimals: true })}</p>
+      ),
+      sorter: (a, b) => a.unapplied_payments_ammount - b.unapplied_payments_ammount,
+      showSorterTooltip: false
     },
     {
       align: "right",

--- a/src/context/ModalContext.tsx
+++ b/src/context/ModalContext.tsx
@@ -49,6 +49,7 @@ interface ModalDetailPaymentProps {
 interface ModalSendEmailProps {
   event: string;
   onFinalOk?: () => void;
+  customOnReject?: () => void;
 }
 
 type ModalProps =


### PR DESCRIPTION
This pull request introduces several improvements and new features to the modal components and client view table. The changes mainly focus on enhancing the functionality of the `ModalSendEmail` component by adding a custom rejection handler, and improving the sorting capabilities of the `ClientsViewTable`.

Enhancements to modal components:

* [`src/components/molecules/modals/ModalSendEmail/ModalSendEmail.tsx`](diffhunk://#diff-4ae8a9187d7e00ac605daffcfd4ab01127ee08fcd162fb4e80f8002a6ecaac94R42-R44): Added a `customOnReject` prop to the `Props` interface and updated the `ModalSendEmail` component to handle a custom rejection function. This includes adding the `handleRejectSendingEmail` function and updating the `SecondaryButton` to use this new handler. [[1]](diffhunk://#diff-4ae8a9187d7e00ac605daffcfd4ab01127ee08fcd162fb4e80f8002a6ecaac94R42-R44) [[2]](diffhunk://#diff-4ae8a9187d7e00ac605daffcfd4ab01127ee08fcd162fb4e80f8002a6ecaac94R103-R107) [[3]](diffhunk://#diff-4ae8a9187d7e00ac605daffcfd4ab01127ee08fcd162fb4e80f8002a6ecaac94L141-R147)
* [`src/components/molecules/modals/RegisterNewsConcilation/RegisterNewsConcilation.tsx`](diffhunk://#diff-e48529cfb06eb5a6ce0875c4a4152b13599877ba067e4cf278a89b5fc3ab25c7R157-R159): Added a `customOnReject` function to the modal configuration to handle custom rejection behavior.
* [`src/context/ModalContext.tsx`](diffhunk://#diff-b7535e49dee67ca9182b50212b83377e3d2585b9c12ea019be6a485c45fed4e9R52): Added the `customOnReject` prop to the `ModalSendEmailProps` interface to support custom rejection handling.

Improvements to client view table:

* [`src/components/organisms/Customers/ClientsViewTable/ClientsViewTable.tsx`](diffhunk://#diff-1f62dddf2612672ceb6a04e463f16994b93cdeff6c997efc3d70449406906544L169-R173): Enhanced the `unapplied_payments_ammount` column by adding a sorter function and disabling the sorter tooltip.