### PR TITLE
Fix/replaceaxios4 instance

### DIFF
--- a/src/components/organisms/projects/DetailProjectView/DetailProjectView.tsx
+++ b/src/components/organisms/projects/DetailProjectView/DetailProjectView.tsx
@@ -33,7 +33,7 @@ export const DetailsProjectView = () => {
       const response = await updateProject(finalData, projectId, data?.UUID || "");
       if (response.status === SUCCESS) {
         showMessage("success", "El proyecto fue editado exitosamente.");
-        // window.location.reload();
+        window.location.reload();
       }
       setIsEditProject(false);
     } catch (error) {

--- a/src/components/organisms/projects/DetailProjectView/DetailProjectView.tsx
+++ b/src/components/organisms/projects/DetailProjectView/DetailProjectView.tsx
@@ -33,7 +33,7 @@ export const DetailsProjectView = () => {
       const response = await updateProject(finalData, projectId, data?.UUID || "");
       if (response.status === SUCCESS) {
         showMessage("success", "El proyecto fue editado exitosamente.");
-        window.location.reload();
+        // window.location.reload();
       }
       setIsEditProject(false);
     } catch (error) {

--- a/src/services/projects/projects.ts
+++ b/src/services/projects/projects.ts
@@ -76,7 +76,7 @@ export const addProject = async (data: IFormProject): Promise<ICreateProject> =>
   }
 
   try {
-    const response: ICreateProject = await axios.post(`${config.API_HOST}/project`, formData, {
+    const response: ICreateProject = await API.post(`${config.API_HOST}/project`, formData, {
       headers: {
         Accept: "application/json, text/plain, */*",
         "Content-Type": "multipart/form-data",
@@ -95,7 +95,6 @@ export const updateProject = async (
   id: string,
   UUID: string
 ): Promise<ICreateProject> => {
-  const token = await getIdToken();
   const currenciesFinal = data.general.currencies.map((currency) => ({
     id: currency.value,
     currency_name: currency.label
@@ -131,6 +130,8 @@ export const updateProject = async (
       billingPeriod.day_flag === "true" ? undefined : billingPeriod.day_of_week.toLowerCase()
   };
 
+  console.log("LOGO DATA: ", finalData.logo);
+
   const formData = new FormData();
   formData.append("id", id);
   formData.append("uuid", UUID);
@@ -164,17 +165,19 @@ export const updateProject = async (
     formData.append("day_of_week", finalData.day_of_week);
   }
 
+  // print only the logo key in the formdata
+  console.log("logo inform ", formData.get("logo"));
+
   try {
-    const response: ICreateProject = await axios.put(`${config.API_HOST}/project`, formData, {
+    const response: ICreateProject = await API.put(`${config.API_HOST}/project`, formData, {
       headers: {
         Accept: "application/json, text/plain, */*",
-        "Content-Type": "multipart/form-data",
-        Authorization: `Bearer ${token}`
+        "Content-Type": "multipart/form-data"
       }
     });
     return response;
   } catch (error) {
-    console.warn("eRROR updating project: ", error);
+    console.warn("error updating project: ", error);
     return error as any;
   }
 };

--- a/src/services/projects/projects.ts
+++ b/src/services/projects/projects.ts
@@ -13,7 +13,6 @@ import { GenericResponse } from "@/types/global/IGlobal";
 import { IProject } from "@/types/projects/IProject";
 
 export const addProject = async (data: IFormProject): Promise<ICreateProject> => {
-  const token = await getIdToken();
   const currenciesFinal = data.general.currencies.map((currency) => ({
     id: currency.value,
     currency_name: currency.label
@@ -76,13 +75,7 @@ export const addProject = async (data: IFormProject): Promise<ICreateProject> =>
   }
 
   try {
-    const response: ICreateProject = await API.post(`${config.API_HOST}/project`, formData, {
-      headers: {
-        Accept: "application/json, text/plain, */*",
-        "Content-Type": "multipart/form-data",
-        Authorization: `Bearer ${token}`
-      }
-    });
+    const response: ICreateProject = await API.post(`${config.API_HOST}/project`, formData);
     return response;
   } catch (error) {
     console.warn("error creating project: ", error);

--- a/src/services/projects/projects.ts
+++ b/src/services/projects/projects.ts
@@ -130,8 +130,6 @@ export const updateProject = async (
       billingPeriod.day_flag === "true" ? undefined : billingPeriod.day_of_week.toLowerCase()
   };
 
-  console.log("LOGO DATA: ", finalData.logo);
-
   const formData = new FormData();
   formData.append("id", id);
   formData.append("uuid", UUID);
@@ -165,16 +163,9 @@ export const updateProject = async (
     formData.append("day_of_week", finalData.day_of_week);
   }
 
-  // print only the logo key in the formdata
-  console.log("logo inform ", formData.get("logo"));
-
   try {
-    const response: ICreateProject = await API.put(`${config.API_HOST}/project`, formData, {
-      headers: {
-        Accept: "application/json, text/plain, */*",
-        "Content-Type": "multipart/form-data"
-      }
-    });
+    const response: ICreateProject = await API.put(`${config.API_HOST}/project`, formData);
+
     return response;
   } catch (error) {
     console.warn("error updating project: ", error);

--- a/src/utils/api/api.ts
+++ b/src/utils/api/api.ts
@@ -85,7 +85,6 @@ instance.interceptors.request.use((request) => {
   return request;
 });
 
-
 // set tokens in instance
 instance.interceptors.request.use(async (request) => {
   const token = (await getIdToken(false)) as string;
@@ -95,7 +94,6 @@ instance.interceptors.request.use(async (request) => {
 
 API.interceptors.request.use(async (request) => {
   request.headers.set("Accept", "application/json, text/plain, */*");
-  request.headers.set("Content-Type", "application/json; charset=utf-8");
   request.headers.set("Authorization", `Bearer ${await getIdToken()}`);
   return request;
 });


### PR DESCRIPTION
Probando el editar proyecto noté que el header de content type seteado en la instancia no permitia enviar archivos o multipart/formData (así se cambiaran los headers al utilizar la instancia, el otro tiene prioridad) y por eso aunque eran satisfactorias las request lo relacionado a archivos no funcionaba (como el cambio de imagen), axios dependiendo del tipo de data que se le está pasando puede usualmente inferir ese Header y por ahora parece que no es necesario setearlo en la creación de la instancia.