### PR TITLE
refactor: update email body formatting and change API call to use API…

### DIFF
--- a/src/components/molecules/modals/ModalSendEmail/ModalSendEmail.tsx
+++ b/src/components/molecules/modals/ModalSendEmail/ModalSendEmail.tsx
@@ -114,8 +114,19 @@ export const ModalSendEmail = ({ isOpen, onClose, onFinalOk, customOnReject }: P
 
   const onSubmit = async (data: IFormEmailNotification) => {
     setLoading(true);
+
+    const parsedEmailBody = data.body
+      .split("\n")
+      .map((line) => `<p>${line}</p>`)
+      .join("\n");
+
+    const modelData = {
+      ...data,
+      body: parsedEmailBody
+    };
+
     try {
-      await sendEmailNotification(data);
+      await sendEmailNotification(modelData);
       // change view to success view if email was sent
       setCurrentView("success");
     } catch (error) {

--- a/src/services/communications/communications.ts
+++ b/src/services/communications/communications.ts
@@ -236,7 +236,7 @@ export const sendEmailNotification = async (data: IFormEmailNotification) => {
   });
 
   try {
-    const response: GenericResponse<{ id: number }> = await axios.post(
+    const response: GenericResponse<{ id: number }> = await API.post(
       `${config.API_HOST}/comunication/email`,
       formData,
       {


### PR DESCRIPTION
This pull request includes changes to improve the handling and sending of email notifications in the application. The most important changes include parsing the email body into HTML format before sending and switching from using `axios` to `API` for making the POST request.

Email parsing and formatting:

* [`src/components/molecules/modals/ModalSendEmail/ModalSendEmail.tsx`](diffhunk://#diff-4ae8a9187d7e00ac605daffcfd4ab01127ee08fcd162fb4e80f8002a6ecaac94R117-R129): The email body is now parsed into HTML paragraphs before sending, ensuring better formatting in the email content.

API request handling:

* [`src/services/communications/communications.ts`](diffhunk://#diff-a99b091070f9d476c301cd9941f689ebe0421b9425d7f014f4778e8c152d0647L239-R239): Updated the method to use `API.post` instead of `axios.post` for sending the email notification request.… instance