### PR TITLE
fix: prevent content distortion during collapse animations in collaps…

### DIFF
--- a/src/components/ui/collapse/collapse.scss
+++ b/src/components/ui/collapse/collapse.scss
@@ -12,6 +12,15 @@
             border-bottom: none !important;
             padding-bottom: 0 !important;
         }
+
+        // to prevent the content to appear distorted when the collapse is opening or closing
+        .ant-motion-collapse,
+        .ant-motion-collapse-enter,
+        .ant-motion-collapse-enter-active,
+        .ant-motion-collapse-leave,
+        .ant-motion-collapse-leave-active {
+            display: none !important;
+        }
     }
 
     .ant-collapse-header {


### PR DESCRIPTION
This pull request includes a small change to the `src/components/ui/collapse/collapse.scss` file. The change prevents the content from appearing distorted when the collapse component is opening or closing.

* [`src/components/ui/collapse/collapse.scss`](diffhunk://#diff-55b5762de128193cca74d3a861b6c4d6d485573d2fc369f31895afaaa1bc724fR15-R23): Added CSS rules to hide the collapse content during the transition states to prevent distortion.…e.scss