### PR TITLE
added paymen_id condition

### DIFF
--- a/src/modules/clients/containers/invoice-detail-modal/invoice-detail-modal.tsx
+++ b/src/modules/clients/containers/invoice-detail-modal/invoice-detail-modal.tsx
@@ -507,6 +507,28 @@ const InvoiceDetailModal: FC<InvoiceDetailModalProps> = ({
                                 </div>
                               ) : null}
 
+                              {item.event_type_name === "Pago aplicado" ? (
+                                <div>
+                                  <div className={styles.icons}>
+                                    <Envelope size={14} onClick={() => {}} />
+                                  </div>
+                                  <div className={styles.name}>{`Acción: ${item.user_name}`}</div>
+                                  <div
+                                    className={styles.name}
+                                  >{`Valor: ${formatMoney(item.ammount)}`}</div>
+                                  {item.payment_id && (
+                                    <div className={styles.adjustment}>
+                                      ID del pago:
+                                      <div className={styles.idAdjustment}>
+                                        {item.payment_id}
+                                      </div>
+                                    </div>
+                                  )}
+                                </div>
+                              ) : (
+                                ""
+                              )}
+
                               {item.comments && (
                                 <div className={styles.commentsContainer}>
                                   <div className={styles.name}>Comentario: {item.comments}</div>

--- a/src/types/clients/invoice-detail.ts
+++ b/src/types/clients/invoice-detail.ts
@@ -33,6 +33,7 @@ export interface IData {
   is_deleted: number;
   is_legalized: number;
   is_rejected: number | null;
+  payment_id: number | null;
   payment_agreement_id: number;
   previous_status: string | null;
   previous_status_id: number | null;


### PR DESCRIPTION
This pull request includes changes to the `InvoiceDetailModal` component and the `IData` interface to add new functionality related to payment details. The most important changes are:

Enhancements to `InvoiceDetailModal` component:

* Added a new section to display payment details when the `event_type_name` is "Pago aplicado". This includes showing the user name, formatted amount, and payment ID if available. (`src/modules/clients/containers/invoice-detail-modal/invoice-detail-modal.tsx`)

Updates to `IData` interface:

* Added a new field `payment_id` to the `IData` interface to store the payment ID. (`src/types/clients/invoice-detail.ts`)